### PR TITLE
Remove Blink.req_reload? from sample code.

### DIFF
--- a/public_html/codemirror.js
+++ b/public_html/codemirror.js
@@ -11,14 +11,6 @@ while true do
   # Blue
   LED.set([0, 0, 255])
   sleep 1
-
-  # Check if reload is requested
-  # This line is crucial in OpenBlink applications. It allows the program to gracefully exit
-  # the current execution loop when a code reload is requested through the Bluetooth interface.
-  # Without this check, the program would continue running and ignore reload requests,
-  # making development and debugging difficult. This mechanism enables the "Blink" feature -
-  # the ability to update code wirelessly in less than 0.1 seconds without restarting the microprocessor.
-  break if Blink.req_reload?
 end
 `;
 


### PR DESCRIPTION
This pull request removes the `break if Blink.req_reload?` from the main execution loop in sample code as it is no longer required.