### PR TITLE
Add mrubyc submodule and initialize with latest commit

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "emsdk"]
 	path = emsdk
 	url = https://github.com/emscripten-core/emsdk
+[submodule "mrubyc"]
+	path = mrubyc
+	url = https://github.com/mrubyc/mrubyc


### PR DESCRIPTION
This pull request adds a new submodule to the repository. The main change is the inclusion of the `mrubyc` submodule, which will allow the project to use or integrate with the mruby/c runtime.

Submodule additions:

* Added the `mrubyc` submodule to `.gitmodules`, specifying its path and repository URL.
* Added the initial commit reference for the `mrubyc` submodule in the `mrubyc` directory.