### PR TITLE
Fix release workflow: add missing mrubyc autogen step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,9 @@ jobs:
         with:
           ruby-version: "3.3"
 
+      - name: Generate mrubyc auto-generated files
+        run: cd mrubyc && make autogen
+
       - name: Build WebAssembly artifacts
         run: make all
 


### PR DESCRIPTION
## Problem

The Release workflow was failing with the following error:



This occurred because the Release workflow's build job was missing the step to generate mrubyc auto-generated files, while the CI workflow's build-wasm job included this step.

## Root Cause

The CI workflow () includes a step "Generate mrubyc auto-generated files" that runs cd src && /Library/Developer/CommandLineTools/usr/bin/make autogen
/Library/Developer/CommandLineTools/usr/bin/make _autogen_builtin_symbol.h _autogen_unicode_case.h
make[2]: `_autogen_builtin_symbol.h' is up to date.
make[2]: `_autogen_unicode_case.h' is up to date.. This generates required header files like  before building WebAssembly artifacts.

The Release workflow () was missing this step in its build job, causing compilation to fail when the compiler couldn't find the auto-generated header files.

## Solution

Add the missing "Generate mrubyc auto-generated files" step to the Release workflow's build job, positioned after "Setup Ruby" and before "Build WebAssembly artifacts". This ensures consistency between both workflows.

## Changes

- Added step to generate mrubyc auto-generated files in release.yml build job
- Matches the same step present in CI workflow's build-wasm job

## Testing

This change will be verified when the next release tag is pushed, as the Release workflow only runs on tag pushes.