### PR TITLE
Fix: Remove unnecessary mrbc_build directory from release archive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,9 @@ jobs:
       - name: Build WebAssembly artifacts
         run: make all
 
+      - name: Clean mrbc build artifacts
+        run: make clean-mrbc
+
       - name: Verify build artifacts
         run: |
           for f in public_html/mrbc/mrbc.js public_html/mrbc/mrbc.wasm public_html/mrubyc/mrubyc.js public_html/mrubyc/mrubyc.wasm; do

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,6 @@ clean-mrbc:
 	@echo "Cleaning mrbc build artifacts..."
 	cd mruby && make clean || true
 	rm -rf public_html/mrbc_build
-	rm -f public_html/mrbc/mrbc.js public_html/mrbc/mrbc.wasm
 
 clean-mrubyc:
 	@echo "Cleaning mrubyc build artifacts..."


### PR DESCRIPTION
## Summary

This PR fixes an issue where the intermediate  directory generated during the mruby build process was being included in the release archive.

## Changes

- **release.yml**: Added Cleaning mrbc build artifacts...
cd mruby && make clean || true
rake clean
Cleaned up target build directory
rm -rf public_html/mrbc_build step after building WebAssembly artifacts to remove the unnecessary  directory
- **Makefile**: Modified the  target to only remove the  directory while preserving the required  and  files

## Impact

The release archive will no longer include the intermediate build directory, resulting in a cleaner and more appropriate release package.