### PR TITLE
Fix CI build-wasm job: add Node.js setup and npm install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,15 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Use Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
       - name: Setup Emscripten
         uses: mymindstorm/setup-emsdk@v14
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,15 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Use Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
       - name: Setup Emscripten
         uses: mymindstorm/setup-emsdk@v14
         with:

--- a/.github/workflows/wasm-build.yml
+++ b/.github/workflows/wasm-build.yml
@@ -29,6 +29,15 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Use Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
       - name: Setup Emscripten
         uses: mymindstorm/setup-emsdk@v14
         with:


### PR DESCRIPTION
The build-wasm job was failing because npm dependencies were not installed. Added Node.js 22 setup and npm ci to the build-wasm workflow to ensure node_modules are available for CodeMirror build.