### PR TITLE
build(deps): update esbuild and eslint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@codemirror/legacy-modes": "^6.5.3",
         "@codemirror/theme-one-dark": "^6.1.3",
         "codemirror": "^6.0.2",
-        "esbuild": "^0.28.0",
+        "esbuild": "^0.28.1",
         "esbuild-css-modules-plugin": "^3.1.5"
       },
       "devDependencies": {
@@ -126,9 +126,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -142,9 +142,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -158,9 +158,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -174,9 +174,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -190,9 +190,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -206,9 +206,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -222,9 +222,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -238,9 +238,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -254,9 +254,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -270,9 +270,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -286,9 +286,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -302,9 +302,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -318,9 +318,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -334,9 +334,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -350,9 +350,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -366,9 +366,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -382,9 +382,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -398,9 +398,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -414,9 +414,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -430,9 +430,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -446,9 +446,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -462,9 +462,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -478,9 +478,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -494,9 +494,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -510,9 +510,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -526,9 +526,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -997,9 +997,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -1009,32 +1009,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/esbuild-css-modules-plugin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "eslint": "^10.4.1",
+        "eslint": "^10.5.0",
         "globals": "^17.6.0",
         "htmlhint": "^1.9.2"
       }
@@ -1067,11 +1067,14 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.1.tgz",
-      "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
+      "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
       "dev": true,
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "eslint": "^10.4.1",
+    "eslint": "^10.5.0",
     "globals": "^17.6.0",
     "htmlhint": "^1.9.2"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@codemirror/legacy-modes": "^6.5.3",
     "@codemirror/theme-one-dark": "^6.1.3",
     "codemirror": "^6.0.2",
-    "esbuild": "^0.28.0",
+    "esbuild": "^0.28.1",
     "esbuild-css-modules-plugin": "^3.1.5"
   }
 }

--- a/public_html/codemirror/codemirror.js
+++ b/public_html/codemirror/codemirror.js
@@ -4,21 +4,21 @@
   var rangeTo = [];
   (() => {
     let numbers = "lc,34,7n,7,7b,19,,,,2,,2,,,20,b,1c,l,g,,2t,7,2,6,2,2,,4,z,,u,r,2j,b,1m,9,9,,o,4,,9,,3,,5,17,3,3b,f,,w,1j,,,,4,8,4,,3,7,a,2,t,,1m,,,,2,4,8,,9,,a,2,q,,2,2,1l,,4,2,4,2,2,3,3,,u,2,3,,b,2,1l,,4,5,,2,4,,k,2,m,6,,,1m,,,2,,4,8,,7,3,a,2,u,,1n,,,,c,,9,,14,,3,,1l,3,5,3,,4,7,2,b,2,t,,1m,,2,,2,,3,,5,2,7,2,b,2,s,2,1l,2,,,2,4,8,,9,,a,2,t,,20,,4,,2,3,,,8,,29,,2,7,c,8,2q,,2,9,b,6,22,2,r,,,,,,1j,e,,5,,2,5,b,,10,9,,2u,4,,6,,2,2,2,p,2,4,3,g,4,d,,2,2,6,,f,,jj,3,qa,3,t,3,t,2,u,2,1s,2,,7,8,,2,b,9,,19,3,3b,2,y,,3a,3,4,2,9,,6,3,63,2,2,,1m,,,7,,,,,2,8,6,a,2,,1c,h,1r,4,1c,7,,,5,,14,9,c,2,w,4,2,2,,3,1k,,,2,3,,,3,1m,8,2,2,48,3,,d,,7,4,,6,,3,2,5i,1m,,5,ek,,5f,x,2da,3,3x,,2o,w,fe,6,2x,2,n9w,4,,a,w,2,28,2,7k,,3,,4,,p,2,5,,47,2,q,i,d,,12,8,p,b,1a,3,1c,,2,4,2,2,13,,1v,6,2,2,2,2,c,,8,,1b,,1f,,,3,2,2,5,2,,,16,2,8,,6m,,2,,4,,fn4,,kh,g,g,g,a6,2,gt,,6a,,45,5,1ae,3,,2,5,4,14,3,4,,4l,2,fx,4,ar,2,49,b,4w,,1i,f,1k,3,1d,4,2,2,1x,3,10,5,,8,1q,,c,2,1g,9,a,4,2,,2n,3,2,,,2,6,,4g,,3,8,l,2,1l,2,,,,,m,,e,7,3,5,5f,8,2,3,,,n,,29,,2,6,,,2,,,2,,2,6j,,2,4,6,2,,2,r,2,2d,8,2,,,2,2y,,,,2,6,,,2t,3,2,4,,5,77,9,,2,6t,,a,2,,,4,,40,4,2,2,4,,w,a,14,6,2,4,8,,9,6,2,3,1a,d,,2,ba,7,,6,,,2a,m,2,7,,2,,2,3e,6,3,,,2,,7,,,20,2,3,,,,9n,2,f0b,5,1n,7,t4,,1r,4,29,,f5k,2,43q,,,3,4,5,8,8,2,7,u,4,44,3,1iz,1j,4,1e,8,,e,,m,5,,f,11s,7,,h,2,7,,2,,5,79,7,c5,4,15s,7,31,7,240,5,gx7k,2o,3k,6o".split(",").map((s) => s ? parseInt(s, 36) : 1);
-    for (let i = 0, n = 0; i < numbers.length; i++)
-      (i % 2 ? rangeTo : rangeFrom).push(n = n + numbers[i]);
+    for (let i2 = 0, n = 0; i2 < numbers.length; i2++)
+      (i2 % 2 ? rangeTo : rangeFrom).push(n = n + numbers[i2]);
   })();
-  function isExtendingChar(code) {
-    if (code < 768) return false;
+  function isExtendingChar(code2) {
+    if (code2 < 768) return false;
     for (let from = 0, to = rangeFrom.length; ; ) {
       let mid = from + to >> 1;
-      if (code < rangeFrom[mid]) to = mid;
-      else if (code >= rangeTo[mid]) from = mid + 1;
+      if (code2 < rangeFrom[mid]) to = mid;
+      else if (code2 >= rangeTo[mid]) from = mid + 1;
       else return true;
       if (from == to) return false;
     }
   }
-  function isRegionalIndicator(code) {
-    return code >= 127462 && code <= 127487;
+  function isRegionalIndicator(code2) {
+    return code2 >= 127462 && code2 <= 127487;
   }
   var ZWJ = 8205;
   function findClusterBreak(str, pos, forward = true, includeExtending = true) {
@@ -35,10 +35,10 @@
         pos += codePointSize(next);
         prev = next;
       } else if (isRegionalIndicator(next)) {
-        let countBefore = 0, i = pos - 2;
-        while (i >= 0 && isRegionalIndicator(codePointAt(str, i))) {
+        let countBefore = 0, i2 = pos - 2;
+        while (i2 >= 0 && isRegionalIndicator(codePointAt(str, i2))) {
           countBefore++;
-          i -= 2;
+          i2 -= 2;
         }
         if (countBefore % 2 == 0) break;
         else pos += 2;
@@ -69,8 +69,8 @@
   function surrogateHigh(ch) {
     return ch >= 55296 && ch < 56320;
   }
-  function codePointSize(code) {
-    return code < 65536 ? 1 : 2;
+  function codePointSize(code2) {
+    return code2 < 65536 ? 1 : 2;
   }
 
   // node_modules/@codemirror/state/dist/index.js
@@ -236,8 +236,8 @@
       return null;
     }
     lineInner(target, isLine, line, offset) {
-      for (let i = 0; ; i++) {
-        let string2 = this.text[i], end = offset + string2.length;
+      for (let i2 = 0; ; i2++) {
+        let string2 = this.text[i2], end = offset + string2.length;
         if ((isLine ? line : end) >= target)
           return new Line(offset, end, line, string2);
         offset = end + 1;
@@ -272,9 +272,9 @@
     sliceString(from, to = this.length, lineSep = "\n") {
       [from, to] = clip(this, from, to);
       let result = "";
-      for (let pos = 0, i = 0; pos <= to && i < this.text.length; i++) {
-        let line = this.text[i], end = pos + line.length;
-        if (pos > from && i)
+      for (let pos = 0, i2 = 0; pos <= to && i2 < this.text.length; i2++) {
+        let line = this.text[i2], end = pos + line.length;
+        if (pos > from && i2)
           result += lineSep;
         if (from < end && to > pos)
           result += line.slice(Math.max(0, from - pos), to - pos);
@@ -315,8 +315,8 @@
         this.lines += child.lines;
     }
     lineInner(target, isLine, line, offset) {
-      for (let i = 0; ; i++) {
-        let child = this.children[i], end = offset + child.length, endLine = line + child.lines - 1;
+      for (let i2 = 0; ; i2++) {
+        let child = this.children[i2], end = offset + child.length, endLine = line + child.lines - 1;
         if ((isLine ? endLine : end) >= target)
           return child.lineInner(target, isLine, line, offset);
         offset = end + 1;
@@ -324,8 +324,8 @@
       }
     }
     decompose(from, to, target, open) {
-      for (let i = 0, pos = 0; pos <= to && i < this.children.length; i++) {
-        let child = this.children[i], end = pos + child.length;
+      for (let i2 = 0, pos = 0; pos <= to && i2 < this.children.length; i2++) {
+        let child = this.children[i2], end = pos + child.length;
         if (from <= end && to >= pos) {
           let childOpen = open & ((pos <= from ? 1 : 0) | (end >= to ? 2 : 0));
           if (pos >= from && end <= to && !childOpen)
@@ -339,14 +339,14 @@
     replace(from, to, text) {
       [from, to] = clip(this, from, to);
       if (text.lines < this.lines)
-        for (let i = 0, pos = 0; i < this.children.length; i++) {
-          let child = this.children[i], end = pos + child.length;
+        for (let i2 = 0, pos = 0; i2 < this.children.length; i2++) {
+          let child = this.children[i2], end = pos + child.length;
           if (from >= pos && to <= end) {
             let updated = child.replace(from - pos, to - pos, text);
             let totalLines = this.lines - child.lines + updated.lines;
             if (updated.lines < totalLines >> 5 - 1 && updated.lines > totalLines >> 5 + 1) {
               let copy = this.children.slice();
-              copy[i] = updated;
+              copy[i2] = updated;
               return new _TextNode(copy, this.length - (to - from) + text.length);
             }
             return super.replace(pos, end, updated);
@@ -358,9 +358,9 @@
     sliceString(from, to = this.length, lineSep = "\n") {
       [from, to] = clip(this, from, to);
       let result = "";
-      for (let i = 0, pos = 0; i < this.children.length && pos <= to; i++) {
-        let child = this.children[i], end = pos + child.length;
-        if (pos > from && i)
+      for (let i2 = 0, pos = 0; i2 < this.children.length && pos <= to; i2++) {
+        let child = this.children[i2], end = pos + child.length;
+        if (pos > from && i2)
           result += lineSep;
         if (from < end && to > pos)
           result += child.sliceString(from - pos, to - pos, lineSep);
@@ -443,8 +443,8 @@
     return length;
   }
   function appendText(text, target, from = 0, to = 1e9) {
-    for (let pos = 0, i = 0, first = true; i < text.length && pos <= to; i++) {
-      let line = text[i], end = pos + line.length;
+    for (let pos = 0, i2 = 0, first = true; i2 < text.length && pos <= to; i2++) {
+      let line = text[i2], end = pos + line.length;
       if (end >= from) {
         if (end > to)
           line = line.slice(0, to - pos);
@@ -642,14 +642,14 @@
       return code0;
     return (code0 - 55296 << 10) + (code1 - 56320) + 65536;
   }
-  function fromCodePoint(code) {
-    if (code <= 65535)
-      return String.fromCharCode(code);
-    code -= 65536;
-    return String.fromCharCode((code >> 10) + 55296, (code & 1023) + 56320);
+  function fromCodePoint(code2) {
+    if (code2 <= 65535)
+      return String.fromCharCode(code2);
+    code2 -= 65536;
+    return String.fromCharCode((code2 >> 10) + 55296, (code2 & 1023) + 56320);
   }
-  function codePointSize2(code) {
-    return code < 65536 ? 1 : 2;
+  function codePointSize2(code2) {
+    return code2 < 65536 ? 1 : 2;
   }
   var DefaultSplit = /\r\n?|\n/;
   var MapMode = /* @__PURE__ */ (function(MapMode2) {
@@ -676,8 +676,8 @@
     */
     get length() {
       let result = 0;
-      for (let i = 0; i < this.sections.length; i += 2)
-        result += this.sections[i];
+      for (let i2 = 0; i2 < this.sections.length; i2 += 2)
+        result += this.sections[i2];
       return result;
     }
     /**
@@ -685,9 +685,9 @@
     */
     get newLength() {
       let result = 0;
-      for (let i = 0; i < this.sections.length; i += 2) {
-        let ins = this.sections[i + 1];
-        result += ins < 0 ? this.sections[i] : ins;
+      for (let i2 = 0; i2 < this.sections.length; i2 += 2) {
+        let ins = this.sections[i2 + 1];
+        result += ins < 0 ? this.sections[i2] : ins;
       }
       return result;
     }
@@ -703,8 +703,8 @@
     the new position in the changed document.
     */
     iterGaps(f) {
-      for (let i = 0, posA = 0, posB = 0; i < this.sections.length; ) {
-        let len = this.sections[i++], ins = this.sections[i++];
+      for (let i2 = 0, posA = 0, posB = 0; i2 < this.sections.length; ) {
+        let len = this.sections[i2++], ins = this.sections[i2++];
         if (ins < 0) {
           f(posA, posB, len);
           posB += len;
@@ -734,8 +734,8 @@
     */
     get invertedDesc() {
       let sections = [];
-      for (let i = 0; i < this.sections.length; ) {
-        let len = this.sections[i++], ins = this.sections[i++];
+      for (let i2 = 0; i2 < this.sections.length; ) {
+        let len = this.sections[i2++], ins = this.sections[i2++];
         if (ins < 0)
           sections.push(len, ins);
         else
@@ -762,8 +762,8 @@
     }
     mapPos(pos, assoc = -1, mode = MapMode.Simple) {
       let posA = 0, posB = 0;
-      for (let i = 0; i < this.sections.length; ) {
-        let len = this.sections[i++], ins = this.sections[i++], endA = posA + len;
+      for (let i2 = 0; i2 < this.sections.length; ) {
+        let len = this.sections[i2++], ins = this.sections[i2++], endA = posA + len;
         if (ins < 0) {
           if (endA > pos)
             return posB + (pos - posA);
@@ -787,8 +787,8 @@
     returned.
     */
     touchesRange(from, to = from) {
-      for (let i = 0, pos = 0; i < this.sections.length && pos <= to; ) {
-        let len = this.sections[i++], ins = this.sections[i++], end = pos + len;
+      for (let i2 = 0, pos = 0; i2 < this.sections.length && pos <= to; ) {
+        let len = this.sections[i2++], ins = this.sections[i2++], end = pos + len;
         if (ins >= 0 && pos <= to && end >= from)
           return pos < from && end > to ? "cover" : true;
         pos = end;
@@ -800,8 +800,8 @@
     */
     toString() {
       let result = "";
-      for (let i = 0; i < this.sections.length; ) {
-        let len = this.sections[i++], ins = this.sections[i++];
+      for (let i2 = 0; i2 < this.sections.length; ) {
+        let len = this.sections[i2++], ins = this.sections[i2++];
         result += (result ? " " : "") + len + (ins >= 0 ? ":" + ins : "");
       }
       return result;
@@ -854,12 +854,12 @@
     */
     invert(doc2) {
       let sections = this.sections.slice(), inserted = [];
-      for (let i = 0, pos = 0; i < sections.length; i += 2) {
-        let len = sections[i], ins = sections[i + 1];
+      for (let i2 = 0, pos = 0; i2 < sections.length; i2 += 2) {
+        let len = sections[i2], ins = sections[i2 + 1];
         if (ins >= 0) {
-          sections[i] = ins;
-          sections[i + 1] = len;
-          let index = i >> 1;
+          sections[i2] = ins;
+          sections[i2 + 1] = len;
+          let index = i2 >> 1;
           while (inserted.length < index)
             inserted.push(Text.empty);
           inserted.push(len ? doc2.slice(pos, pos + len) : Text.empty);
@@ -918,8 +918,8 @@
     filter(ranges) {
       let resultSections = [], resultInserted = [], filteredSections = [];
       let iter = new SectionIter(this);
-      done: for (let i = 0, pos = 0; ; ) {
-        let next = i == ranges.length ? 1e9 : ranges[i++];
+      done: for (let i2 = 0, pos = 0; ; ) {
+        let next = i2 == ranges.length ? 1e9 : ranges[i2++];
         while (pos < next || pos == next && iter.len == 0) {
           if (iter.done)
             break done;
@@ -932,7 +932,7 @@
           iter.forward(len);
           pos += len;
         }
-        let end = ranges[i++];
+        let end = ranges[i2++];
         while (pos < end) {
           if (iter.done)
             break done;
@@ -953,14 +953,14 @@
     */
     toJSON() {
       let parts = [];
-      for (let i = 0; i < this.sections.length; i += 2) {
-        let len = this.sections[i], ins = this.sections[i + 1];
+      for (let i2 = 0; i2 < this.sections.length; i2 += 2) {
+        let len = this.sections[i2], ins = this.sections[i2 + 1];
         if (ins < 0)
           parts.push(len);
         else if (ins == 0)
           parts.push([len]);
         else
-          parts.push([len].concat(this.inserted[i >> 1].toJSON()));
+          parts.push([len].concat(this.inserted[i2 >> 1].toJSON()));
       }
       return parts;
     }
@@ -1026,19 +1026,19 @@
       if (!Array.isArray(json))
         throw new RangeError("Invalid JSON representation of ChangeSet");
       let sections = [], inserted = [];
-      for (let i = 0; i < json.length; i++) {
-        let part = json[i];
+      for (let i2 = 0; i2 < json.length; i2++) {
+        let part = json[i2];
         if (typeof part == "number") {
           sections.push(part, -1);
-        } else if (!Array.isArray(part) || typeof part[0] != "number" || part.some((e, i2) => i2 && typeof e != "string")) {
+        } else if (!Array.isArray(part) || typeof part[0] != "number" || part.some((e, i3) => i3 && typeof e != "string")) {
           throw new RangeError("Invalid JSON representation of ChangeSet");
         } else if (part.length == 1) {
           sections.push(part[0], 0);
         } else {
-          while (inserted.length < i)
+          while (inserted.length < i2)
             inserted.push(Text.empty);
-          inserted[i] = Text.of(part.slice(1));
-          sections.push(part[0], inserted[i].length);
+          inserted[i2] = Text.of(part.slice(1));
+          sections.push(part[0], inserted[i2].length);
         }
       }
       return new _ChangeSet(sections, inserted);
@@ -1078,8 +1078,8 @@
   }
   function iterChanges(desc, f, individual) {
     let inserted = desc.inserted;
-    for (let posA = 0, posB = 0, i = 0; i < desc.sections.length; ) {
-      let len = desc.sections[i++], ins = desc.sections[i++];
+    for (let posA = 0, posB = 0, i2 = 0; i2 < desc.sections.length; ) {
+      let len = desc.sections[i2++], ins = desc.sections[i2++];
       if (ins < 0) {
         posA += len;
         posB += len;
@@ -1089,11 +1089,11 @@
           endA += len;
           endB += ins;
           if (ins && inserted)
-            text = text.append(inserted[i - 2 >> 1]);
-          if (individual || i == desc.sections.length || desc.sections[i + 1] < 0)
+            text = text.append(inserted[i2 - 2 >> 1]);
+          if (individual || i2 == desc.sections.length || desc.sections[i2 + 1] < 0)
             break;
-          len = desc.sections[i++];
-          ins = desc.sections[i++];
+          len = desc.sections[i2++];
+          ins = desc.sections[i2++];
         }
         f(posA, endA, posB, endB, text);
         posA = endA;
@@ -1370,8 +1370,8 @@
     eq(other, includeAssoc = false) {
       if (this.ranges.length != other.ranges.length || this.mainIndex != other.mainIndex)
         return false;
-      for (let i = 0; i < this.ranges.length; i++)
-        if (!this.ranges[i].eq(other.ranges[i], includeAssoc))
+      for (let i2 = 0; i2 < this.ranges.length; i2++)
+        if (!this.ranges[i2].eq(other.ranges[i2], includeAssoc))
           return false;
       return true;
     }
@@ -1433,8 +1433,8 @@
     static create(ranges, mainIndex = 0) {
       if (ranges.length == 0)
         throw new RangeError("A selection needs at least one range");
-      for (let pos = 0, i = 0; i < ranges.length; i++) {
-        let range = ranges[i];
+      for (let pos = 0, i2 = 0; i2 < ranges.length; i2++) {
+        let range = ranges[i2];
         if (range.empty ? range.from <= pos : range.from < pos)
           return _EditorSelection.normalized(ranges.slice(), mainIndex);
         pos = range.to;
@@ -1464,13 +1464,13 @@
       let main = ranges[mainIndex];
       ranges.sort((a, b) => a.from - b.from);
       mainIndex = ranges.indexOf(main);
-      for (let i = 1; i < ranges.length; i++) {
-        let range = ranges[i], prev = ranges[i - 1];
+      for (let i2 = 1; i2 < ranges.length; i2++) {
+        let range = ranges[i2], prev = ranges[i2 - 1];
         if (range.empty ? range.from <= prev.to : range.from < prev.to) {
           let from = prev.from, to = Math.max(range.to, prev.to);
-          if (i <= mainIndex)
+          if (i2 <= mainIndex)
             mainIndex--;
-          ranges.splice(--i, 2, range.anchor > range.head ? _EditorSelection.range(to, from) : _EditorSelection.range(from, to));
+          ranges.splice(--i2, 2, range.anchor > range.head ? _EditorSelection.range(to, from) : _EditorSelection.range(from, to));
         }
       }
       return new _EditorSelection(ranges, mainIndex);
@@ -1541,7 +1541,7 @@
     }
   };
   function sameArray(a, b) {
-    return a == b || a.length == b.length && a.every((e, i) => e === b[i]);
+    return a == b || a.length == b.length && a.every((e, i2) => e === b[i2]);
   }
   var FacetProvider = class {
     constructor(dependencies, facet, type, value) {
@@ -1602,8 +1602,8 @@
   function compareArray(a, b, compare2) {
     if (a.length != b.length)
       return false;
-    for (let i = 0; i < a.length; i++)
-      if (!compare2(a[i], b[i]))
+    for (let i2 = 0; i2 < a.length; i2++)
+      if (!compare2(a[i2], b[i2]))
         return false;
     return true;
   }
@@ -1621,9 +1621,9 @@
     let idx = addresses[facet.id] >> 1;
     function get(state) {
       let values = [];
-      for (let i = 0; i < providerAddrs.length; i++) {
-        let value = getAddr(state, providerAddrs[i]);
-        if (providerTypes[i] == 2)
+      for (let i2 = 0; i2 < providerAddrs.length; i2++) {
+        let value = getAddr(state, providerAddrs[i2]);
+        if (providerTypes[i2] == 2)
           for (let val of value)
             values.push(val);
         else
@@ -1684,7 +1684,7 @@
       return field;
     }
     create(state) {
-      let init = state.facet(initField).find((i) => i.field == this);
+      let init = state.facet(initField).find((i2) => i2.field == this);
       return ((init === null || init === void 0 ? void 0 : init.create) || this.createF)(state);
     }
     /**
@@ -1707,7 +1707,7 @@
         },
         reconfigure: (state, oldState) => {
           let init = state.facet(initField), oldInit = oldState.facet(initField), reInit;
-          if ((reInit = init.find((i) => i.field == this)) && reInit != oldInit.find((i) => i.field == this)) {
+          if ((reInit = init.find((i2) => i2.field == this)) && reInit != oldInit.find((i2) => i2.field == this)) {
             state.values[idx] = reInit.create(state);
             return 1;
           }
@@ -2180,11 +2180,11 @@
     let s = resolveTransactionInner(state, specs.length ? specs[0] : {}, state.doc.length);
     if (specs.length && specs[0].filter === false)
       filter = false;
-    for (let i = 1; i < specs.length; i++) {
-      if (specs[i].filter === false)
+    for (let i2 = 1; i2 < specs.length; i2++) {
+      if (specs[i2].filter === false)
         filter = false;
-      let seq = !!specs[i].sequential;
-      s = mergeTransaction(s, resolveTransactionInner(state, specs[i], seq ? s.changes.newLength : state.doc.length), seq);
+      let seq = !!specs[i2].sequential;
+      s = mergeTransaction(s, resolveTransactionInner(state, specs[i2], seq ? s.changes.newLength : state.doc.length), seq);
     }
     let tr = Transaction.create(state, s.changes, s.selection, s.effects, s.annotations, s.scrollIntoView);
     return extendTransaction(filter ? filterTransaction(tr) : tr);
@@ -2214,8 +2214,8 @@
       tr = Transaction.create(state, changes, tr.selection && tr.selection.map(back), StateEffect.mapEffects(tr.effects, back), tr.annotations, tr.scrollIntoView);
     }
     let filters = state.facet(transactionFilter);
-    for (let i = filters.length - 1; i >= 0; i--) {
-      let filtered = filters[i](tr);
+    for (let i2 = filters.length - 1; i2 >= 0; i2--) {
+      let filtered = filters[i2](tr);
       if (filtered instanceof Transaction)
         tr = filtered;
       else if (Array.isArray(filtered) && filtered.length == 1 && filtered[0] instanceof Transaction)
@@ -2227,8 +2227,8 @@
   }
   function extendTransaction(tr) {
     let state = tr.startState, extenders = state.facet(transactionExtender), spec = tr;
-    for (let i = extenders.length - 1; i >= 0; i--) {
-      let extension = extenders[i](tr);
+    for (let i2 = extenders.length - 1; i2 >= 0; i2--) {
+      let extension = extenders[i2](tr);
       if (extension && Object.keys(extension).length)
         spec = mergeTransaction(spec, resolveTransactionInner(state, extension, tr.changes.newLength), true);
     }
@@ -2253,8 +2253,8 @@
   function hasWordChar(str) {
     if (wordChar)
       return wordChar.test(str);
-    for (let i = 0; i < str.length; i++) {
-      let ch = str[i];
+    for (let i2 = 0; i2 < str.length; i2++) {
+      let ch = str[i2];
       if (/\w/.test(ch) || ch > "\x80" && (ch.toUpperCase() != ch.toLowerCase() || nonASCIISingleCaseWordChar.test(ch)))
         return true;
     }
@@ -2266,8 +2266,8 @@
         return CharCategory.Space;
       if (hasWordChar(char))
         return CharCategory.Word;
-      for (let i = 0; i < wordChars.length; i++)
-        if (char.indexOf(wordChars[i]) > -1)
+      for (let i2 = 0; i2 < wordChars.length; i2++)
+        if (char.indexOf(wordChars[i2]) > -1)
           return CharCategory.Word;
       return CharCategory.Other;
     };
@@ -2282,8 +2282,8 @@
       this.computeSlot = computeSlot;
       if (tr)
         tr._state = this;
-      for (let i = 0; i < this.config.dynamicSlots.length; i++)
-        ensureAddr(this, i << 1);
+      for (let i2 = 0; i2 < this.config.dynamicSlots.length; i2++)
+        ensureAddr(this, i2 << 1);
       this.computeSlot = null;
     }
     field(field, require2 = true) {
@@ -2374,10 +2374,10 @@
       let result1 = f(sel.ranges[0]);
       let changes = this.changes(result1.changes), ranges = [result1.range];
       let effects = asArray(result1.effects);
-      for (let i = 1; i < sel.ranges.length; i++) {
-        let result = f(sel.ranges[i]);
+      for (let i2 = 1; i2 < sel.ranges.length; i2++) {
+        let result = f(sel.ranges[i2]);
         let newChanges = this.changes(result.changes), newMapped = newChanges.map(changes);
-        for (let j = 0; j < i; j++)
+        for (let j = 0; j < i2; j++)
           ranges[j] = ranges[j].map(newMapped);
         let mapBy = changes.mapDesc(newChanges, true);
         ranges.push(result.range.map(mapBy));
@@ -2518,10 +2518,10 @@
           break;
         }
       if (insert2.length)
-        phrase2 = phrase2.replace(/\$(\$|\d*)/g, (m, i) => {
-          if (i == "$")
+        phrase2 = phrase2.replace(/\$(\$|\d*)/g, (m, i2) => {
+          if (i2 == "$")
             return "$";
-          let n = +(i || 1);
+          let n = +(i2 || 1);
           return !n || n > insert2.length ? m : insert2[n - 1];
         });
       return phrase2;
@@ -2695,14 +2695,14 @@
       }
     }
     between(offset, from, to, f) {
-      for (let i = this.findIndex(from, -1e9, true), e = this.findIndex(to, 1e9, false, i); i < e; i++)
-        if (f(this.from[i] + offset, this.to[i] + offset, this.value[i]) === false)
+      for (let i2 = this.findIndex(from, -1e9, true), e = this.findIndex(to, 1e9, false, i2); i2 < e; i2++)
+        if (f(this.from[i2] + offset, this.to[i2] + offset, this.value[i2]) === false)
           return false;
     }
     map(offset, changes) {
       let value = [], from = [], to = [], newPos = -1, maxPoint = -1;
-      for (let i = 0; i < this.value.length; i++) {
-        let val = this.value[i], curFrom = this.from[i] + offset, curTo = this.to[i] + offset, newFrom, newTo;
+      for (let i2 = 0; i2 < this.value.length; i2++) {
+        let val = this.value[i2], curFrom = this.from[i2] + offset, curTo = this.to[i2] + offset, newFrom, newTo;
         if (curFrom == curTo) {
           let mapped = changes.mapPos(curFrom, val.startSide, val.mapMode);
           if (mapped == null)
@@ -2787,14 +2787,14 @@
         add2 = add2.slice().sort(cmpRange);
       if (this.isEmpty)
         return add2.length ? _RangeSet.of(add2) : this;
-      let cur2 = new LayerCursor(this, null, -1).goto(0), i = 0, spill = [];
+      let cur2 = new LayerCursor(this, null, -1).goto(0), i2 = 0, spill = [];
       let builder = new RangeSetBuilder();
-      while (cur2.value || i < add2.length) {
-        if (i < add2.length && (cur2.from - add2[i].from || cur2.startSide - add2[i].value.startSide) >= 0) {
-          let range = add2[i++];
+      while (cur2.value || i2 < add2.length) {
+        if (i2 < add2.length && (cur2.from - add2[i2].from || cur2.startSide - add2[i2].value.startSide) >= 0) {
+          let range = add2[i2++];
           if (!builder.addInner(range.from, range.to, range.value))
             spill.push(range);
-        } else if (cur2.rangeIndex == 1 && cur2.chunkIndex < this.chunk.length && (i == add2.length || this.chunkEnd(cur2.chunkIndex) < add2[i].from) && (!filter || filterFrom > this.chunkEnd(cur2.chunkIndex) || filterTo < this.chunkPos[cur2.chunkIndex]) && builder.addChunk(this.chunkPos[cur2.chunkIndex], this.chunk[cur2.chunkIndex])) {
+        } else if (cur2.rangeIndex == 1 && cur2.chunkIndex < this.chunk.length && (i2 == add2.length || this.chunkEnd(cur2.chunkIndex) < add2[i2].from) && (!filter || filterFrom > this.chunkEnd(cur2.chunkIndex) || filterTo < this.chunkPos[cur2.chunkIndex]) && builder.addChunk(this.chunkPos[cur2.chunkIndex], this.chunk[cur2.chunkIndex])) {
           cur2.nextChunk();
         } else {
           if (!filter || filterFrom > cur2.to || filterTo < cur2.from || filter(cur2.from, cur2.to, cur2.value)) {
@@ -2813,8 +2813,8 @@
       if (changes.empty || this.isEmpty)
         return this;
       let chunks = [], chunkPos = [], maxPoint = -1;
-      for (let i = 0; i < this.chunk.length; i++) {
-        let start = this.chunkPos[i], chunk = this.chunk[i];
+      for (let i2 = 0; i2 < this.chunk.length; i2++) {
+        let start = this.chunkPos[i2], chunk = this.chunk[i2];
         let touch = changes.touchesRange(start, start + chunk.length);
         if (touch === false) {
           maxPoint = Math.max(maxPoint, chunk.maxPoint);
@@ -2841,8 +2841,8 @@
     between(from, to, f) {
       if (this.isEmpty)
         return;
-      for (let i = 0; i < this.chunk.length; i++) {
-        let start = this.chunkPos[i], chunk = this.chunk[i];
+      for (let i2 = 0; i2 < this.chunk.length; i2++) {
+        let start = this.chunkPos[i2], chunk = this.chunk[i2];
         if (to >= start && from <= start + chunk.length && chunk.between(start, from - start, to - start, f) === false)
           return;
       }
@@ -2953,8 +2953,8 @@
       if (!sets.length)
         return _RangeSet.empty;
       let result = sets[sets.length - 1];
-      for (let i = sets.length - 2; i >= 0; i--) {
-        for (let layer2 = sets[i]; layer2 != _RangeSet.empty; layer2 = layer2.nextLayer)
+      for (let i2 = sets.length - 2; i2 >= 0; i2--) {
+        for (let layer2 = sets[i2]; layer2 != _RangeSet.empty; layer2 = layer2.nextLayer)
           result = new _RangeSet(layer2.chunkPos, layer2.chunk, result, Math.max(layer2.maxPoint, result.maxPoint));
       }
       return result;
@@ -2963,8 +2963,8 @@
   RangeSet.empty = /* @__PURE__ */ new RangeSet([], [], null, -1);
   function lazySort(ranges) {
     if (ranges.length > 1)
-      for (let prev = ranges[0], i = 1; i < ranges.length; i++) {
-        let cur2 = ranges[i];
+      for (let prev = ranges[0], i2 = 1; i2 < ranges.length; i2++) {
+        let cur2 = ranges[i2];
         if (cmpRange(prev, cur2) > 0)
           return ranges.slice().sort(cmpRange);
         prev = cur2;
@@ -3073,15 +3073,15 @@
   function findSharedChunks(a, b, textDiff) {
     let inA = /* @__PURE__ */ new Map();
     for (let set of a)
-      for (let i = 0; i < set.chunk.length; i++)
-        if (set.chunk[i].maxPoint <= 0)
-          inA.set(set.chunk[i], set.chunkPos[i]);
+      for (let i2 = 0; i2 < set.chunk.length; i2++)
+        if (set.chunk[i2].maxPoint <= 0)
+          inA.set(set.chunk[i2], set.chunkPos[i2]);
     let shared = /* @__PURE__ */ new Set();
     for (let set of b)
-      for (let i = 0; i < set.chunk.length; i++) {
-        let known = inA.get(set.chunk[i]);
-        if (known != null && (textDiff ? textDiff.mapPos(known) : known) == set.chunkPos[i] && !(textDiff === null || textDiff === void 0 ? void 0 : textDiff.touchesRange(known, known + set.chunk[i].length)))
-          shared.add(set.chunk[i]);
+      for (let i2 = 0; i2 < set.chunk.length; i2++) {
+        let known = inA.get(set.chunk[i2]);
+        if (known != null && (textDiff ? textDiff.mapPos(known) : known) == set.chunkPos[i2] && !(textDiff === null || textDiff === void 0 ? void 0 : textDiff.touchesRange(known, known + set.chunk[i2].length)))
+          shared.add(set.chunk[i2]);
       }
     return shared;
   }
@@ -3167,10 +3167,10 @@
     }
     static from(sets, skip = null, minPoint = -1) {
       let heap = [];
-      for (let i = 0; i < sets.length; i++) {
-        for (let cur2 = sets[i]; !cur2.isEmpty; cur2 = cur2.nextLayer) {
+      for (let i2 = 0; i2 < sets.length; i2++) {
+        for (let cur2 = sets[i2]; !cur2.isEmpty; cur2 = cur2.nextLayer) {
           if (cur2.maxPoint >= minPoint)
-            heap.push(new LayerCursor(cur2, skip, minPoint, i));
+            heap.push(new LayerCursor(cur2, skip, minPoint, i2));
         }
       }
       return heap.length == 1 ? heap[0] : new _HeapCursor(heap);
@@ -3181,16 +3181,16 @@
     goto(pos, side = -1e9) {
       for (let cur2 of this.heap)
         cur2.goto(pos, side);
-      for (let i = this.heap.length >> 1; i >= 0; i--)
-        heapBubble(this.heap, i);
+      for (let i2 = this.heap.length >> 1; i2 >= 0; i2--)
+        heapBubble(this.heap, i2);
       this.next();
       return this;
     }
     forward(pos, side) {
       for (let cur2 of this.heap)
         cur2.forward(pos, side);
-      for (let i = this.heap.length >> 1; i >= 0; i--)
-        heapBubble(this.heap, i);
+      for (let i2 = this.heap.length >> 1; i2 >= 0; i2--)
+        heapBubble(this.heap, i2);
       if ((this.to - pos || this.value.endSide - side) < 0)
         this.next();
     }
@@ -3265,14 +3265,14 @@
       this.minActive = findMinIndex(this.active, this.activeTo);
     }
     addActive(trackOpen) {
-      let i = 0, { value, to, rank } = this.cursor;
-      while (i < this.activeRank.length && (rank - this.activeRank[i] || to - this.activeTo[i]) > 0)
-        i++;
-      insert(this.active, i, value);
-      insert(this.activeTo, i, to);
-      insert(this.activeRank, i, rank);
+      let i2 = 0, { value, to, rank } = this.cursor;
+      while (i2 < this.activeRank.length && (rank - this.activeRank[i2] || to - this.activeTo[i2]) > 0)
+        i2++;
+      insert(this.active, i2, value);
+      insert(this.activeTo, i2, to);
+      insert(this.activeRank, i2, rank);
       if (trackOpen)
-        insert(trackOpen, i, this.cursor.from);
+        insert(trackOpen, i2, this.cursor.from);
       this.minActive = findMinIndex(this.active, this.activeTo);
     }
     // After calling this, if `this.point` != null, the next range is a
@@ -3320,7 +3320,7 @@
       }
       if (trackOpen) {
         this.openStart = 0;
-        for (let i = trackOpen.length - 1; i >= 0 && trackOpen[i] < from; i--)
+        for (let i2 = trackOpen.length - 1; i2 >= 0 && trackOpen[i2] < from; i2--)
           this.openStart++;
       }
     }
@@ -3328,17 +3328,17 @@
       if (!this.active.length)
         return this.active;
       let active = [];
-      for (let i = this.active.length - 1; i >= 0; i--) {
-        if (this.activeRank[i] < this.pointRank)
+      for (let i2 = this.active.length - 1; i2 >= 0; i2--) {
+        if (this.activeRank[i2] < this.pointRank)
           break;
-        if (this.activeTo[i] > to || this.activeTo[i] == to && this.active[i].endSide >= this.point.endSide)
-          active.push(this.active[i]);
+        if (this.activeTo[i2] > to || this.activeTo[i2] == to && this.active[i2].endSide >= this.point.endSide)
+          active.push(this.active[i2]);
       }
       return active.reverse();
     }
     openEnd(to) {
       let open = 0;
-      for (let i = this.activeTo.length - 1; i >= 0 && this.activeTo[i] > to; i--)
+      for (let i2 = this.activeTo.length - 1; i2 >= 0 && this.activeTo[i2] > to; i2--)
         open++;
       return open;
     }
@@ -3377,51 +3377,51 @@
   function sameValues(a, b) {
     if (a.length != b.length)
       return false;
-    for (let i = 0; i < a.length; i++)
-      if (a[i] != b[i] && !cmpVal(a[i], b[i]))
+    for (let i2 = 0; i2 < a.length; i2++)
+      if (a[i2] != b[i2] && !cmpVal(a[i2], b[i2]))
         return false;
     return true;
   }
   function remove(array, index) {
-    for (let i = index, e = array.length - 1; i < e; i++)
-      array[i] = array[i + 1];
+    for (let i2 = index, e = array.length - 1; i2 < e; i2++)
+      array[i2] = array[i2 + 1];
     array.pop();
   }
   function insert(array, index, value) {
-    for (let i = array.length - 1; i >= index; i--)
-      array[i + 1] = array[i];
+    for (let i2 = array.length - 1; i2 >= index; i2--)
+      array[i2 + 1] = array[i2];
     array[index] = value;
   }
   function findMinIndex(value, array) {
     let found = -1, foundPos = 1e9;
-    for (let i = 0; i < array.length; i++)
-      if ((array[i] - foundPos || value[i].endSide - value[found].endSide) < 0) {
-        found = i;
-        foundPos = array[i];
+    for (let i2 = 0; i2 < array.length; i2++)
+      if ((array[i2] - foundPos || value[i2].endSide - value[found].endSide) < 0) {
+        found = i2;
+        foundPos = array[i2];
       }
     return found;
   }
   function countColumn(string2, tabSize, to = string2.length) {
     let n = 0;
-    for (let i = 0; i < to && i < string2.length; ) {
-      if (string2.charCodeAt(i) == 9) {
+    for (let i2 = 0; i2 < to && i2 < string2.length; ) {
+      if (string2.charCodeAt(i2) == 9) {
         n += tabSize - n % tabSize;
-        i++;
+        i2++;
       } else {
         n++;
-        i = findClusterBreak2(string2, i);
+        i2 = findClusterBreak2(string2, i2);
       }
     }
     return n;
   }
   function findColumn(string2, col, tabSize, strict) {
-    for (let i = 0, n = 0; ; ) {
+    for (let i2 = 0, n = 0; ; ) {
       if (n >= col)
-        return i;
-      if (i == string2.length)
+        return i2;
+      if (i2 == string2.length)
         break;
-      n += string2.charCodeAt(i) == 9 ? tabSize - n % tabSize : 1;
-      i = findClusterBreak2(string2, i);
+      n += string2.charCodeAt(i2) == 9 ? tabSize - n % tabSize : 1;
+      i2 = findClusterBreak2(string2, i2);
     }
     return strict === true ? -1 : string2.length;
   }
@@ -3521,8 +3521,8 @@
     mount(modules, root) {
       let sheet = this.sheet;
       let pos = 0, j = 0;
-      for (let i = 0; i < modules.length; i++) {
-        let mod = modules[i], index = this.modules.indexOf(mod);
+      for (let i2 = 0; i2 < modules.length; i2++) {
+        let mod = modules[i2], index = this.modules.indexOf(mod);
         if (index < j && index > -1) {
           this.modules.splice(index, 1);
           j--;
@@ -3543,8 +3543,8 @@
           root.adoptedStyleSheets = [this.sheet, ...root.adoptedStyleSheets];
       } else {
         let text = "";
-        for (let i = 0; i < this.modules.length; i++)
-          text += this.modules[i].getRules() + "\n";
+        for (let i2 = 0; i2 < this.modules.length; i2++)
+          text += this.modules[i2].getRules() + "\n";
         this.styleTag.textContent = text;
         let target = root.head || root;
         if (this.styleTag.parentNode != target)
@@ -3667,16 +3667,16 @@
   function crelt() {
     var elt = arguments[0];
     if (typeof elt == "string") elt = document.createElement(elt);
-    var i = 1, next = arguments[1];
+    var i2 = 1, next = arguments[1];
     if (next && typeof next == "object" && next.nodeType == null && !Array.isArray(next)) {
       for (var name2 in next) if (Object.prototype.hasOwnProperty.call(next, name2)) {
         var value = next[name2];
         if (typeof value == "string") elt.setAttribute(name2, value);
         else if (value != null) elt[name2] = value;
       }
-      i++;
+      i2++;
     }
-    for (; i < arguments.length; i++) add(elt, arguments[i]);
+    for (; i2 < arguments.length; i2++) add(elt, arguments[i2]);
     return elt;
   }
   function add(elt, child) {
@@ -3686,7 +3686,7 @@
     } else if (child.nodeType != null) {
       elt.appendChild(child);
     } else if (Array.isArray(child)) {
-      for (var i = 0; i < child.length; i++) add(elt, child[i]);
+      for (var i2 = 0; i2 < child.length; i2++) add(elt, child[i2]);
     } else {
       throw new RangeError("Unsupported child node: " + child);
     }
@@ -3751,8 +3751,8 @@
     return true;
   }
   function setAttrs(dom, attrs) {
-    for (let i = dom.attributes.length - 1; i >= 0; i--) {
-      let name2 = dom.attributes[i].name;
+    for (let i2 = dom.attributes.length - 1; i2 >= 0; i2--) {
+      let name2 = dom.attributes[i2].name;
       if (attrs[name2] == null)
         dom.removeAttribute(name2);
     }
@@ -3790,8 +3790,8 @@
   }
   function getAttrs(dom) {
     let attrs = /* @__PURE__ */ Object.create(null);
-    for (let i = 0; i < dom.attributes.length; i++) {
-      let attr = dom.attributes[i];
+    for (let i2 = 0; i2 < dom.attributes.length; i2++) {
+      let attr = dom.attributes[i2];
       attrs[attr.name] = attr.value;
     }
     return attrs;
@@ -4318,8 +4318,8 @@
     } : void 0);
     if (!preventScrollSupported) {
       preventScrollSupported = false;
-      for (let i = 0; i < stack.length; ) {
-        let elt = stack[i++], top2 = stack[i++], left = stack[i++];
+      for (let i2 = 0; i2 < stack.length; ) {
+        let elt = stack[i2++], top2 = stack[i2++], left = stack[i2++];
         if (elt.scrollTop != top2)
           elt.scrollTop = top2;
         if (elt.scrollLeft != left)
@@ -4334,8 +4334,8 @@
     range.setStart(node, from);
     return range;
   }
-  function dispatchKey(elt, name2, code, mods) {
-    let options = { key: name2, code: name2, keyCode: code, which: code, cancelable: true };
+  function dispatchKey(elt, name2, code2, mods) {
+    let options = { key: name2, code: name2, keyCode: code2, which: code2, cancelable: true };
     if (mods)
       ({ altKey: options.altKey, ctrlKey: options.ctrlKey, shiftKey: options.shiftKey, metaKey: options.metaKey } = mods);
     let down = new KeyboardEvent("keydown", options);
@@ -4439,8 +4439,8 @@
   var RTL = Direction.RTL;
   function dec(str) {
     let result = [];
-    for (let i = 0; i < str.length; i++)
-      result.push(1 << +str[i]);
+    for (let i2 = 0; i2 < str.length; i2++)
+      result.push(1 << +str[i2]);
     return result;
   }
   var LowTypes = /* @__PURE__ */ dec("88888888888888888888888888888888888666888888787833333333337888888000000000000000000000000008888880000000000000000000000000088888888888888888888888888888888888887866668888088888663380888308888800000000000000000000000800000000000000000000000000000008");
@@ -4488,13 +4488,13 @@
     */
     static find(order, index, level, assoc) {
       let maybe = -1;
-      for (let i = 0; i < order.length; i++) {
-        let span = order[i];
+      for (let i2 = 0; i2 < order.length; i2++) {
+        let span = order[i2];
         if (span.from <= index && span.to >= index) {
           if (span.level == level)
-            return i;
+            return i2;
           if (maybe < 0 || (assoc != 0 ? assoc < 0 ? span.from < index : span.to > index : order[maybe].level > span.level))
-            maybe = i;
+            maybe = i2;
         }
       }
       if (maybe < 0)
@@ -4505,8 +4505,8 @@
   function isolatesEq(a, b) {
     if (a.length != b.length)
       return false;
-    for (let i = 0; i < a.length; i++) {
-      let iA = a[i], iB = b[i];
+    for (let i2 = 0; i2 < a.length; i2++) {
+      let iA = a[i2], iB = b[i2];
       if (iA.from != iB.from || iA.to != iB.to || iA.direction != iB.direction || !isolatesEq(iA.inner, iB.inner))
         return false;
     }
@@ -4517,34 +4517,34 @@
     for (let iI = 0; iI <= isolates.length; iI++) {
       let from = iI ? isolates[iI - 1].to : rFrom, to = iI < isolates.length ? isolates[iI].from : rTo;
       let prevType = iI ? 256 : outerType;
-      for (let i = from, prev = prevType, prevStrong = prevType; i < to; i++) {
-        let type = charType(line.charCodeAt(i));
+      for (let i2 = from, prev = prevType, prevStrong = prevType; i2 < to; i2++) {
+        let type = charType(line.charCodeAt(i2));
         if (type == 512)
           type = prev;
         else if (type == 8 && prevStrong == 4)
           type = 16;
-        types[i] = type == 4 ? 2 : type;
+        types[i2] = type == 4 ? 2 : type;
         if (type & 7)
           prevStrong = type;
         prev = type;
       }
-      for (let i = from, prev = prevType, prevStrong = prevType; i < to; i++) {
-        let type = types[i];
+      for (let i2 = from, prev = prevType, prevStrong = prevType; i2 < to; i2++) {
+        let type = types[i2];
         if (type == 128) {
-          if (i < to - 1 && prev == types[i + 1] && prev & 24)
-            type = types[i] = prev;
+          if (i2 < to - 1 && prev == types[i2 + 1] && prev & 24)
+            type = types[i2] = prev;
           else
-            types[i] = 256;
+            types[i2] = 256;
         } else if (type == 64) {
-          let end = i + 1;
+          let end = i2 + 1;
           while (end < to && types[end] == 64)
             end++;
-          let replace2 = i && prev == 8 || end < rTo && types[end] == 8 ? prevStrong == 1 ? 1 : 8 : 256;
-          for (let j = i; j < end; j++)
+          let replace2 = i2 && prev == 8 || end < rTo && types[end] == 8 ? prevStrong == 1 ? 1 : 8 : 256;
+          for (let j = i2; j < end; j++)
             types[j] = replace2;
-          i = end - 1;
+          i2 = end - 1;
         } else if (type == 8 && prevStrong == 1) {
-          types[i] = 1;
+          types[i2] = 1;
         }
         prev = type;
         if (type & 7)
@@ -4556,15 +4556,15 @@
     let oppositeType = outerType == 1 ? 2 : 1;
     for (let iI = 0, sI = 0, context = 0; iI <= isolates.length; iI++) {
       let from = iI ? isolates[iI - 1].to : rFrom, to = iI < isolates.length ? isolates[iI].from : rTo;
-      for (let i = from, ch, br, type; i < to; i++) {
-        if (br = Brackets[ch = line.charCodeAt(i)]) {
+      for (let i2 = from, ch, br, type; i2 < to; i2++) {
+        if (br = Brackets[ch = line.charCodeAt(i2)]) {
           if (br < 0) {
             for (let sJ = sI - 3; sJ >= 0; sJ -= 3) {
               if (BracketStack[sJ + 1] == -br) {
                 let flags = BracketStack[sJ + 2];
                 let type2 = flags & 2 ? outerType : !(flags & 4) ? 0 : flags & 1 ? oppositeType : outerType;
                 if (type2)
-                  types[i] = types[BracketStack[sJ]] = type2;
+                  types[i2] = types[BracketStack[sJ]] = type2;
                 sI = sJ;
                 break;
               }
@@ -4572,11 +4572,11 @@
           } else if (BracketStack.length == 189) {
             break;
           } else {
-            BracketStack[sI++] = i;
+            BracketStack[sI++] = i2;
             BracketStack[sI++] = ch;
             BracketStack[sI++] = context;
           }
-        } else if ((type = types[i]) == 2 || type == 1) {
+        } else if ((type = types[i2]) == 2 || type == 1) {
           let embed = type == outerType;
           context = embed ? 0 : 1;
           for (let sJ = sI - 3; sJ >= 0; sJ -= 3) {
@@ -4598,10 +4598,10 @@
   function processNeutrals(rFrom, rTo, isolates, outerType) {
     for (let iI = 0, prev = outerType; iI <= isolates.length; iI++) {
       let from = iI ? isolates[iI - 1].to : rFrom, to = iI < isolates.length ? isolates[iI].from : rTo;
-      for (let i = from; i < to; ) {
-        let type = types[i];
+      for (let i2 = from; i2 < to; ) {
+        let type = types[i2];
         if (type == 256) {
-          let end = i + 1;
+          let end = i2 + 1;
           for (; ; ) {
             if (end == to) {
               if (iI == isolates.length)
@@ -4617,17 +4617,17 @@
           let beforeL = prev == 1;
           let afterL = (end < rTo ? types[end] : outerType) == 1;
           let replace2 = beforeL == afterL ? beforeL ? 1 : 2 : outerType;
-          for (let j = end, jI = iI, fromJ = jI ? isolates[jI - 1].to : rFrom; j > i; ) {
+          for (let j = end, jI = iI, fromJ = jI ? isolates[jI - 1].to : rFrom; j > i2; ) {
             if (j == fromJ) {
               j = isolates[--jI].from;
               fromJ = jI ? isolates[jI - 1].to : rFrom;
             }
             types[--j] = replace2;
           }
-          i = end;
+          i2 = end;
         } else {
           prev = type;
-          i++;
+          i2++;
         }
       }
     }
@@ -4785,8 +4785,8 @@
     return EditorSelection.cursor(nextIndex + line.from, span.forward(forward, dir) ? -1 : 1, span.level);
   }
   function autoDirection(text, from, to) {
-    for (let i = from; i < to; i++) {
-      let type = charType(text.charCodeAt(i));
+    for (let i2 = from; i2 < to; i2++) {
+      let type = charType(text.charCodeAt(i2));
       if (type == 1)
         return LTR;
       if (type == 2 || type == 4)
@@ -4842,8 +4842,8 @@
   var nextPluginID = 0;
   var viewPlugin = /* @__PURE__ */ Facet.define({
     combine(plugins) {
-      return plugins.filter((p, i) => {
-        for (let j = 0; j < i; j++)
+      return plugins.filter((p, i2) => {
+        for (let j = 0; j < i2; j++)
           if (plugins[j].plugin == p.plugin)
             return false;
         return true;
@@ -4954,7 +4954,7 @@
     let isolates = view.state.facet(bidiIsolatedRanges);
     if (!isolates.length)
       return isolates;
-    let sets = isolates.map((i) => i instanceof Function ? i(view) : i);
+    let sets = isolates.map((i2) => i2 instanceof Function ? i2(view) : i2);
     let result = [];
     RangeSet.spans(sets, line.from, line.to, {
       point() {
@@ -4962,8 +4962,8 @@
       span(fromDoc, toDoc, active, open) {
         let from = fromDoc - line.from, to = toDoc - line.from;
         let level = result;
-        for (let i = active.length - 1; i >= 0; i--, open--) {
-          let direction = active[i].spec.bidiIsolate, update;
+        for (let i2 = active.length - 1; i2 >= 0; i2--, open--) {
+          let direction = active[i2].spec.bidiIsolate, update;
           if (direction == null)
             direction = autoDirection(line.text, from, to);
           if (open > 0 && level.length && (update = level[level.length - 1]).to == from && update.direction == direction) {
@@ -5009,17 +5009,17 @@
       return new _ChangedRange(Math.min(this.fromA, other.fromA), Math.max(this.toA, other.toA), Math.min(this.fromB, other.fromB), Math.max(this.toB, other.toB));
     }
     addToSet(set) {
-      let i = set.length, me = this;
-      for (; i > 0; i--) {
-        let range = set[i - 1];
+      let i2 = set.length, me = this;
+      for (; i2 > 0; i2--) {
+        let range = set[i2 - 1];
         if (range.fromA > me.toA)
           continue;
         if (range.toA < me.fromA)
           break;
         me = me.join(range);
-        set.splice(i - 1, 1);
+        set.splice(i2 - 1, 1);
       }
-      set.splice(i, 0, me);
+      set.splice(i2, 0, me);
       return set;
     }
     // Extend a set to cover all the content in `ranges`, which is a
@@ -5043,8 +5043,8 @@
             let end = ranges[rI + 1];
             rI += 2;
             toB = Math.max(toB, end);
-            for (let i = dI; i < diff.length && diff[i].fromB <= toB; i++)
-              off = diff[i].toA - diff[i].toB;
+            for (let i2 = dI; i2 < diff.length && diff[i2].fromB <= toB; i2++)
+              off = diff[i2].toA - diff[i2].toB;
             toA = Math.max(toA, end + off);
           } else if (dI < diff.length && diff[dI].fromB <= toB) {
             let next = diff[dI++];
@@ -5317,20 +5317,20 @@
       }
     }
     blockTiles(f) {
-      for (let stack = [], cur2 = this, i = 0, pos = 0; ; ) {
-        if (i == cur2.children.length) {
+      for (let stack = [], cur2 = this, i2 = 0, pos = 0; ; ) {
+        if (i2 == cur2.children.length) {
           if (!stack.length)
             return;
           cur2 = cur2.parent;
           if (cur2.breakAfter)
             pos++;
-          i = stack.pop();
+          i2 = stack.pop();
         } else {
-          let next = cur2.children[i++];
+          let next = cur2.children[i2++];
           if (next instanceof BlockWrapperTile) {
-            stack.push(i);
+            stack.push(i2);
             cur2 = next;
-            i = 0;
+            i2 = 0;
           } else {
             let end = pos + next.length;
             let result = f(next, pos);
@@ -5415,8 +5415,8 @@
     resolveInline(pos, side, forCoords) {
       let before = null, beforeOff = -1, after = null, afterOff = -1;
       function scan(tile, pos2) {
-        for (let i = 0, off = 0; i < tile.children.length && off <= pos2; i++) {
-          let child = tile.children[i], end = off + child.length;
+        for (let i2 = 0, off = 0; i2 < tile.children.length && off <= pos2; i2++) {
+          let child = tile.children[i2], end = off + child.length;
           if (end >= pos2) {
             if (child.isComposite()) {
               scan(child, pos2 - off);
@@ -5575,9 +5575,9 @@
         if (!rects.length)
           return null;
         let fromBack = this.flags & 16 ? true : this.flags & 32 ? false : pos > 0;
-        for (let i = fromBack ? rects.length - 1 : 0; ; i += fromBack ? -1 : 1) {
-          rect = rects[i];
-          if (pos > 0 ? i == 0 : i == rects.length - 1 || rect.top < rect.bottom)
+        for (let i2 = fromBack ? rects.length - 1 : 0; ; i2 += fromBack ? -1 : 1) {
+          rect = rects[i2];
+          if (pos > 0 ? i2 == 0 : i2 == rects.length - 1 || rect.top < rect.bottom)
             break;
         }
         return flattenRect(rect, !fromBack);
@@ -5739,8 +5739,8 @@
         );
       }
       let head = line;
-      for (let i = context.marks.length - 1; i >= 0; i--) {
-        let mark = context.marks[i];
+      for (let i2 = context.marks.length - 1; i2 >= 0; i2--) {
+        let mark = context.marks[i2];
         let last = head.lastChild;
         if (last instanceof MarkTile && last.mark.eq(mark.mark)) {
           if (last.dom != mark.dom)
@@ -5832,8 +5832,8 @@
     ensureMarks(marks2, openStart) {
       var _a2;
       let parent2 = this.curLine;
-      for (let i = marks2.length - 1; i >= 0; i--) {
-        let mark = marks2[i], last;
+      for (let i2 = marks2.length - 1; i2 >= 0; i2--) {
+        let mark = marks2[i2], last;
         if (openStart > 0 && (last = parent2.lastChild) && last instanceof MarkTile && last.mark.eq(mark)) {
           parent2 = last;
           openStart--;
@@ -5871,16 +5871,16 @@
         this.blockWrappers.goto(this.pos);
         this.wrappers.length = 0;
       }
-      for (let i = this.wrappers.length - 1; i >= 0; i--)
-        if (this.wrappers[i].to < this.pos)
-          this.wrappers.splice(i, 1);
+      for (let i2 = this.wrappers.length - 1; i2 >= 0; i2--)
+        if (this.wrappers[i2].to < this.pos)
+          this.wrappers.splice(i2, 1);
       for (let cur2 = this.blockWrappers; cur2.value && cur2.from <= this.pos; cur2.next())
         if (cur2.to >= this.pos) {
           let rank = cur2.rank * 102 + cur2.value.rank;
-          let wrap = new OpenWrapper(cur2.from, cur2.to, cur2.value, rank), i = this.wrappers.length;
-          while (i > 0 && (this.wrappers[i - 1].rank - wrap.rank || this.wrappers[i - 1].to - wrap.to) < 0)
-            i--;
-          this.wrappers.splice(i, 0, wrap);
+          let wrap = new OpenWrapper(cur2.from, cur2.to, cur2.value, rank), i2 = this.wrappers.length;
+          while (i2 > 0 && (this.wrappers[i2 - 1].rank - wrap.rank || this.wrappers[i2 - 1].to - wrap.to) < 0)
+            i2--;
+          this.wrappers.splice(i2, 0, wrap);
         }
       this.wrapperPos = this.pos;
     }
@@ -5956,8 +5956,8 @@
     }
   };
   var buckets = [WidgetTile, LineTile, TextTile, MarkTile, WidgetBufferTile, BlockWrapperTile, DocTile];
-  for (let i = 0; i < buckets.length; i++)
-    buckets[i].bucket = i;
+  for (let i2 = 0; i2 < buckets.length; i2++)
+    buckets[i2].bucket = i2;
   var TileCache = class {
     constructor(view) {
       this.view = view;
@@ -5967,24 +5967,24 @@
     }
     // Put a tile in the cache.
     add(tile) {
-      let i = tile.constructor.bucket, bucket = this.buckets[i];
+      let i2 = tile.constructor.bucket, bucket = this.buckets[i2];
       if (bucket.length < 6)
         bucket.push(tile);
       else
         bucket[
-          this.index[i] = (this.index[i] + 1) % 6
+          this.index[i2] = (this.index[i2] + 1) % 6
           /* C.Bucket */
         ] = tile;
     }
     find(cls, test, type = 2) {
-      let i = cls.bucket;
-      let bucket = this.buckets[i], off = this.index[i];
+      let i2 = cls.bucket;
+      let bucket = this.buckets[i2], off = this.index[i2];
       for (let j = bucket.length - 1; j >= 0; j--) {
         let index = (j + off) % bucket.length, tile = bucket[index];
         if ((!test || test(tile)) && !this.reused.has(tile)) {
           bucket.splice(index, 1);
           if (index < off)
-            this.index[i]--;
+            this.index[i2]--;
           this.reused.set(tile, type);
           return tile;
         }
@@ -5994,17 +5994,17 @@
     findWidget(widget, length, flags) {
       let widgets = this.buckets[0];
       if (widgets.length)
-        for (let i = 0, pass = 0; ; i++) {
-          if (i == widgets.length) {
+        for (let i2 = 0, pass = 0; ; i2++) {
+          if (i2 == widgets.length) {
             if (pass)
               return null;
             pass = 1;
-            i = 0;
+            i2 = 0;
           }
-          let tile = widgets[i];
+          let tile = widgets[i2];
           if (!this.reused.has(tile) && (pass == 0 ? tile.widget.compare(widget) : tile.widget.constructor == widget.constructor && widget.updateDOM(tile.dom, this.view, tile.widget))) {
-            widgets.splice(i, 1);
-            if (i < this.index[0])
+            widgets.splice(i2, 1);
+            if (i2 < this.index[0])
               this.index[0]--;
             if (tile.widget == widget && tile.length == length && (tile.flags & (496 | 1)) == flags) {
               this.reused.set(
@@ -6039,8 +6039,8 @@
       return tile.dom;
     }
     clear() {
-      for (let i = 0; i < this.buckets.length; i++)
-        this.buckets[i].length = this.index[i] = 0;
+      for (let i2 = 0; i2 < this.buckets.length; i2++)
+        this.buckets[i2].length = this.index[i2] = 0;
     }
   };
   var TileUpdate = class {
@@ -6074,12 +6074,12 @@
     }
     run(changes, composition) {
       let compositionContext = composition && this.getCompositionContext(composition.text);
-      for (let posA = 0, posB = 0, i = 0; ; ) {
-        let next = i < changes.length ? changes[i++] : null;
+      for (let posA = 0, posB = 0, i2 = 0; ; ) {
+        let next = i2 < changes.length ? changes[i2++] : null;
         let skipA = next ? next.fromA : this.old.root.length;
         if (skipA > posA) {
           let len = skipA - posA;
-          this.preserve(len, !i, !next);
+          this.preserve(len, !i2, !next);
           posA = skipA;
           posB += len;
         }
@@ -6294,8 +6294,8 @@
   }
   function getMarks(ptr) {
     let found = [];
-    for (let i = ptr.parents.length; i > 1; i--) {
-      let tile = i == ptr.parents.length ? ptr.tile : ptr.parents[i].tile;
+    for (let i2 = ptr.parents.length; i2 > 1; i2--) {
+      let tile = i2 == ptr.parents.length ? ptr.tile : ptr.parents[i2].tile;
       if (tile instanceof MarkTile)
         found.push(tile.mark);
     }
@@ -6585,8 +6585,8 @@
           after = after.nextSibling;
         if (!after)
           return start + tile.length;
-        for (let i = 0, pos = start; ; i++) {
-          let child = tile.children[i];
+        for (let i2 = 0, pos = start; ; i2++) {
+          let child = tile.children[i2];
           if (child.dom == after)
             return pos;
           pos += child.length + child.breakAfter;
@@ -6670,9 +6670,9 @@
           if (end == offset2)
             return null;
           let rects = textRange(tile2.dom, offset2, end).getClientRects();
-          for (let i = 0; i < rects.length; i++) {
-            let rect = rects[i];
-            if (i == rects.length - 1 || rect.top < rect.bottom && rect.left < rect.right)
+          for (let i2 = 0; i2 < rects.length; i2++) {
+            let rect = rects[i2];
+            if (i2 == rects.length - 1 || rect.top < rect.bottom && rect.left < rect.right)
               return rect;
           }
         }
@@ -6687,12 +6687,12 @@
       let widest = -1, ltr = this.view.textDirection == Direction.LTR;
       let spaceAbove = 0;
       let scan = (tile, pos, measureBounds) => {
-        for (let i = 0; i < tile.children.length; i++) {
+        for (let i2 = 0; i2 < tile.children.length; i2++) {
           if (pos > to)
             break;
-          let child = tile.children[i], end = pos + child.length;
+          let child = tile.children[i2], end = pos + child.length;
           let childRect = child.dom.getBoundingClientRect(), { height } = childRect;
-          if (measureBounds && !i)
+          if (measureBounds && !i2)
             spaceAbove += childRect.top - measureBounds.top;
           if (child instanceof BlockWrapperTile) {
             if (end > from)
@@ -6717,7 +6717,7 @@
               }
             }
           }
-          if (measureBounds && i == tile.children.length - 1)
+          if (measureBounds && i2 == tile.children.length - 1)
             spaceAbove += measureBounds.bottom - childRect.bottom;
           pos = end + child.breakAfter;
         }
@@ -6769,8 +6769,8 @@
     }
     computeBlockGapDeco() {
       let deco = [], vs = this.view.viewState;
-      for (let pos = 0, i = 0; ; i++) {
-        let next = i == vs.viewports.length ? null : vs.viewports[i];
+      for (let pos = 0, i2 = 0; ; i2++) {
+        let next = i2 == vs.viewports.length ? null : vs.viewports[i2];
         let end = next ? next.from - 1 : this.view.state.doc.length;
         if (end > pos) {
           let height = (vs.lineBlockAt(end).bottom - vs.lineBlockAt(pos).top) / this.view.scaleY;
@@ -6788,19 +6788,19 @@
       return Decoration.set(deco);
     }
     updateDeco() {
-      let i = 1;
+      let i2 = 1;
       let allDeco = this.view.state.facet(decorations).map((d) => {
-        let dynamic = this.dynamicDecorationMap[i++] = typeof d == "function";
+        let dynamic = this.dynamicDecorationMap[i2++] = typeof d == "function";
         return dynamic ? d(this.view) : d;
       });
-      let dynamicOuter = false, outerDeco = this.view.state.facet(outerDecorations).map((d, i2) => {
+      let dynamicOuter = false, outerDeco = this.view.state.facet(outerDecorations).map((d, i3) => {
         let dynamic = typeof d == "function";
         if (dynamic)
           dynamicOuter = true;
         return dynamic ? d(this.view) : d;
       });
       if (outerDeco.length) {
-        this.dynamicDecorationMap[i++] = dynamicOuter;
+        this.dynamicDecorationMap[i2++] = dynamicOuter;
         allDeco.push(RangeSet.join(outerDeco));
       }
       this.decorations = [
@@ -6809,8 +6809,8 @@
         this.computeBlockGapDeco(),
         this.view.viewState.lineGapDeco
       ];
-      while (i < this.decorations.length)
-        this.dynamicDecorationMap[i++] = false;
+      while (i2 < this.decorations.length)
+        this.dynamicDecorationMap[i2++] = false;
       this.blockWrappers = this.view.state.facet(blockWrappers).map((v) => typeof v == "function" ? v(this.view) : v);
     }
     scrollIntoView(target) {
@@ -7150,8 +7150,8 @@
   }
   function skipAtomsForSelection(atoms, sel) {
     let ranges = null;
-    for (let i = 0; i < sel.ranges.length; i++) {
-      let range = sel.ranges[i], updated = null;
+    for (let i2 = 0; i2 < sel.ranges.length; i2++) {
+      let range = sel.ranges[i2], updated = null;
       if (range.empty) {
         let pos = skipAtomicRanges(atoms, range.from, 0);
         if (pos != range.from)
@@ -7165,7 +7165,7 @@
       if (updated) {
         if (!ranges)
           ranges = sel.ranges.slice();
-        ranges[i] = updated;
+        ranges[i2] = updated;
       }
     }
     return ranges ? EditorSelection.create(ranges, sel.mainIndex) : sel;
@@ -7263,7 +7263,7 @@
         let dist2 = hi - lo, mid = lo + hi >> 1;
         adjust: if (seen.has(mid)) {
           let scan = lo + Math.floor(Math.random() * dist2);
-          for (let i = 0; i < dist2; i++) {
+          for (let i2 = 0; i2 < dist2; i2++) {
             if (!seen.has(scan)) {
               mid = scan;
               break adjust;
@@ -7277,8 +7277,8 @@
         seen.add(mid);
         let rects = getRects(mid);
         if (rects)
-          for (let i = 0; i < rects.length; i++) {
-            let rect = rects[i], side = 0;
+          for (let i2 = 0; i2 < rects.length; i2++) {
+            let rect = rects[i2], side = 0;
             if (rect.width == 0 && rects.length > 1)
               continue;
             if (rect.bottom < this.y) {
@@ -7331,11 +7331,11 @@
     }
     scanText(tile, offset) {
       let positions = [];
-      for (let i = 0; i < tile.length; i = findClusterBreak2(tile.text, i))
-        positions.push(offset + i);
+      for (let i2 = 0; i2 < tile.length; i2 = findClusterBreak2(tile.text, i2))
+        positions.push(offset + i2);
       positions.push(offset + tile.length);
-      let scan = this.scan(positions, (i) => {
-        let off = positions[i] - offset, end = positions[i + 1] - offset;
+      let scan = this.scan(positions, (i2) => {
+        let off = positions[i2] - offset, end = positions[i2 + 1] - offset;
         return textRange(tile.dom, off, end).getClientRects();
       });
       return scan.after ? new PosAssoc(positions[scan.i + 1], -1) : new PosAssoc(positions[scan.i], 1);
@@ -7351,10 +7351,10 @@
           return this.scanTile(child2, offset);
       }
       let positions = [offset];
-      for (let i = 0, pos2 = offset; i < tile.children.length; i++)
-        positions.push(pos2 += tile.children[i].length);
-      let scan = this.scan(positions, (i) => {
-        let child2 = tile.children[i];
+      for (let i2 = 0, pos2 = offset; i2 < tile.children.length; i2++)
+        positions.push(pos2 += tile.children[i2].length);
+      let scan = this.scan(positions, (i2) => {
+        let child2 = tile.children[i2];
         if (child2.flags & 48)
           return null;
         return (child2.dom.nodeType == 1 ? child2.dom : textRange(child2.dom, 0, child2.length)).getClientRects();
@@ -7434,11 +7434,11 @@
       let fromView = tile && tile.overrideDOMText;
       if (fromView != null) {
         this.findPointInside(node, fromView.length);
-        for (let i = fromView.iter(); !i.next().done; ) {
-          if (i.lineBreak)
+        for (let i2 = fromView.iter(); !i2.next().done; ) {
+          if (i2.lineBreak)
             this.lineBreak();
           else
-            this.append(i.value);
+            this.append(i2.value);
         }
       } else if (node.nodeType == 3) {
         this.readTextNode(node);
@@ -7540,16 +7540,16 @@
   function domBoundsAround(tile, from, to, offset) {
     if (tile.isComposite()) {
       let fromI = -1, fromStart = -1, toI = -1, toEnd = -1;
-      for (let i = 0, pos = offset, prevEnd = offset; i < tile.children.length; i++) {
-        let child = tile.children[i], end = pos + child.length;
+      for (let i2 = 0, pos = offset, prevEnd = offset; i2 < tile.children.length; i2++) {
+        let child = tile.children[i2], end = pos + child.length;
         if (pos < from && end > to)
           return domBoundsAround(child, from, to, pos);
         if (end >= from && fromI == -1) {
-          fromI = i;
+          fromI = i2;
           fromStart = pos;
         }
         if (pos > to && child.dom.parentNode == tile.dom) {
-          toI = i;
+          toI = i2;
           toEnd = prevEnd;
           break;
         }
@@ -8071,8 +8071,8 @@
     if (!sel || sel.rangeCount == 0)
       return true;
     let rects = sel.getRangeAt(0).getClientRects();
-    for (let i = 0; i < rects.length; i++) {
-      let rect = rects[i];
+    for (let i2 = 0; i2 < rects.length; i2++) {
+      let rect = rects[i2];
       if (rect.left <= event.clientX && rect.right >= event.clientX && rect.top <= event.clientY && rect.bottom >= event.clientY)
         return true;
     }
@@ -8111,7 +8111,7 @@
   }
   function doPaste(view, input) {
     input = textFilter(view.state, clipboardInputFilter, input);
-    let { state } = view, changes, i = 1, text = state.toText(input);
+    let { state } = view, changes, i2 = 1, text = state.toText(input);
     let byLine = text.lines == state.selection.ranges.length;
     let linewise = lastLinewiseCopy != null && state.selection.ranges.every((r) => r.empty) && lastLinewiseCopy == text.toString();
     if (linewise) {
@@ -8121,7 +8121,7 @@
         if (line.from == lastLine)
           return { range };
         lastLine = line.from;
-        let insert2 = state.toText((byLine ? text.line(i++).text : input) + state.lineBreak);
+        let insert2 = state.toText((byLine ? text.line(i2++).text : input) + state.lineBreak);
         return {
           changes: { from: line.from, insert: insert2 },
           range: EditorSelection.cursor(range.from + insert2.length)
@@ -8129,7 +8129,7 @@
       });
     } else if (byLine) {
       changes = state.changeByRange((range) => {
-        let line = text.line(i++);
+        let line = text.line(i2++);
         return {
           changes: { from: range.from, to: range.to, insert: line.text },
           range: EditorSelection.cursor(range.from + line.length)
@@ -8255,10 +8255,10 @@
     };
   }
   function removeRangeAround(sel, pos) {
-    for (let i = 0; i < sel.ranges.length; i++) {
-      let { from, to } = sel.ranges[i];
+    for (let i2 = 0; i2 < sel.ranges.length; i2++) {
+      let { from, to } = sel.ranges[i2];
       if (from <= pos && to >= pos)
-        return EditorSelection.create(sel.ranges.slice(0, i).concat(sel.ranges.slice(i + 1)), sel.mainIndex == i ? 0 : sel.mainIndex - (sel.mainIndex > i ? 1 : 0));
+        return EditorSelection.create(sel.ranges.slice(0, i2).concat(sel.ranges.slice(i2 + 1)), sel.mainIndex == i2 ? 0 : sel.mainIndex - (sel.mainIndex > i2 ? 1 : 0));
     }
     return null;
   }
@@ -8315,15 +8315,15 @@
         if (++read == files.length)
           dropText(view, event, text.filter((s) => s != null).join(view.state.lineBreak), false);
       };
-      for (let i = 0; i < files.length; i++) {
+      for (let i2 = 0; i2 < files.length; i2++) {
         let reader = new FileReader();
         reader.onerror = finishFile;
         reader.onload = () => {
           if (!/[\x00-\x08\x0e-\x1f]{2}/.test(reader.result))
-            text[i] = reader.result;
+            text[i2] = reader.result;
           finishFile();
         };
-        reader.readAsText(files[i]);
+        reader.readAsText(files[i2]);
       }
       return true;
     } else {
@@ -8556,10 +8556,10 @@
     }
     mustRefreshForHeights(lineHeights) {
       let newHeight = false;
-      for (let i = 0; i < lineHeights.length; i++) {
-        let h = lineHeights[i];
+      for (let i2 = 0; i2 < lineHeights.length; i2++) {
+        let h = lineHeights[i2];
         if (h < 0) {
-          i++;
+          i2++;
         } else if (!this.heightSamples[Math.floor(h * 10)]) {
           newHeight = true;
           this.heightSamples[Math.floor(h * 10)] = true;
@@ -8577,10 +8577,10 @@
       this.lineLength = lineLength;
       if (changed) {
         this.heightSamples = {};
-        for (let i = 0; i < knownHeights.length; i++) {
-          let h = knownHeights[i];
+        for (let i2 = 0; i2 < knownHeights.length; i2++) {
+          let h = knownHeights[i2];
           if (h < 0)
-            i++;
+            i2++;
           else
             this.heightSamples[Math.floor(h * 10)] = true;
         }
@@ -8691,16 +8691,16 @@
     }
     applyChanges(decorations2, oldDoc, oracle, changes) {
       let me = this, doc2 = oracle.doc;
-      for (let i = changes.length - 1; i >= 0; i--) {
-        let { fromA, toA, fromB, toB } = changes[i];
+      for (let i2 = changes.length - 1; i2 >= 0; i2--) {
+        let { fromA, toA, fromB, toB } = changes[i2];
         let start = me.lineAt(fromA, QueryType.ByPosNoHeight, oracle.setDoc(oldDoc), 0, 0);
         let end = start.to >= toA ? start : me.lineAt(toA, QueryType.ByPosNoHeight, oracle, 0, 0);
         toB += end.to - toA;
         toA = end.to;
-        while (i > 0 && start.from <= changes[i - 1].toA) {
-          fromA = changes[i - 1].fromA;
-          fromB = changes[i - 1].fromB;
-          i--;
+        while (i2 > 0 && start.from <= changes[i2 - 1].toA) {
+          fromA = changes[i2 - 1].fromA;
+          fromB = changes[i2 - 1].fromB;
+          i2--;
           if (fromA < start.from)
             start = me.lineAt(fromA, QueryType.ByPosNoHeight, oracle, 0, 0);
         }
@@ -8721,15 +8721,15 @@
     static of(nodes) {
       if (nodes.length == 1)
         return nodes[0];
-      let i = 0, j = nodes.length, before = 0, after = 0;
+      let i2 = 0, j = nodes.length, before = 0, after = 0;
       for (; ; ) {
-        if (i == j) {
+        if (i2 == j) {
           if (before > after * 2) {
-            let split = nodes[i - 1];
+            let split = nodes[i2 - 1];
             if (split.break)
-              nodes.splice(--i, 1, split.left, null, split.right);
+              nodes.splice(--i2, 1, split.left, null, split.right);
             else
-              nodes.splice(--i, 1, split.left, split.right);
+              nodes.splice(--i2, 1, split.left, split.right);
             j += 1 + split.break;
             before -= split.size;
           } else if (after > before * 2) {
@@ -8744,7 +8744,7 @@
             break;
           }
         } else if (before < after) {
-          let next = nodes[i++];
+          let next = nodes[i2++];
           if (next)
             before += next.size;
         } else {
@@ -8754,14 +8754,14 @@
         }
       }
       let brk = 0;
-      if (nodes[i - 1] == null) {
+      if (nodes[i2 - 1] == null) {
         brk = 1;
-        i--;
-      } else if (nodes[i] == null) {
+        i2--;
+      } else if (nodes[i2] == null) {
         brk = 1;
         j++;
       }
-      return new HeightMapBranch(_HeightMap.of(nodes.slice(0, i)), brk, _HeightMap.of(nodes.slice(j)));
+      return new HeightMapBranch(_HeightMap.of(nodes.slice(0, i2)), brk, _HeightMap.of(nodes.slice(j)));
     }
   };
   function replace(old, val) {
@@ -9289,8 +9289,8 @@
     static same(a, b) {
       if (a.length != b.length)
         return false;
-      for (let i = 0; i < a.length; i++) {
-        let gA = a[i], gB = b[i];
+      for (let i2 = 0; i2 < a.length; i2++) {
+        let gA = a[i2], gB = b[i2];
         if (gA.from != gB.from || gA.to != gB.to || gA.size != gB.size)
           return false;
       }
@@ -9355,7 +9355,7 @@
       this.heightOracle = new HeightOracle(guessWrapping);
       this.stateDeco = staticDeco(state);
       this.heightMap = HeightMap.empty().applyChanges(this.stateDeco, Text.empty, this.heightOracle.setDoc(state.doc), [new ChangedRange(0, 0, 0, state.doc.length)]);
-      for (let i = 0; i < 2; i++) {
+      for (let i2 = 0; i2 < 2; i2++) {
         this.viewport = this.getViewport(0, null);
         if (!this.updateForViewport())
           break;
@@ -9368,8 +9368,8 @@
     }
     updateForViewport() {
       let viewports = [this.viewport], { main } = this.state.selection;
-      for (let i = 0; i <= 1; i++) {
-        let pos = i ? main.head : main.anchor;
+      for (let i2 = 0; i2 <= 1; i2++) {
+        let pos = i2 ? main.head : main.anchor;
         if (!viewports.some(({ from, to }) => pos >= from && pos <= to)) {
           let { from, to } = this.lineBlockAt(pos);
           viewports.push(new Viewport(from, to));
@@ -9713,8 +9713,8 @@
       if (ranges.length != this.visibleRanges.length) {
         changed = 8 | 4;
       } else {
-        for (let i = 0; i < ranges.length && !(changed & 8); i++) {
-          let old = this.visibleRanges[i], nw = ranges[i];
+        for (let i2 = 0; i2 < ranges.length && !(changed & 8); i2++) {
+          let old = this.visibleRanges[i2], nw = ranges[i2];
           if (old.from != nw.from || old.to != nw.to) {
             changed |= 4;
             if (!(changes && changes.mapPos(old.from, -1) == nw.from && changes.mapPos(old.to, 1) == nw.to))
@@ -9780,8 +9780,8 @@
     if (ratio >= 1)
       return ranges[ranges.length - 1].to;
     let dist2 = Math.floor(total * ratio);
-    for (let i = 0; ; i++) {
-      let { from, to } = ranges[i], size = to - from;
+    for (let i2 = 0; ; i2++) {
+      let { from, to } = ranges[i2], size = to - from;
       if (dist2 <= size)
         return from + dist2;
       dist2 -= size;
@@ -9840,8 +9840,8 @@
       }
     }
     toDOM(n) {
-      for (let i = 0, base2 = 0, domBase = 0; ; i++) {
-        let vp = i < this.viewports.length ? this.viewports[i] : null;
+      for (let i2 = 0, base2 = 0, domBase = 0; ; i2++) {
+        let vp = i2 < this.viewports.length ? this.viewports[i2] : null;
         if (!vp || n < vp.top)
           return domBase + (n - base2) * this.scale;
         if (n <= vp.bottom)
@@ -9851,8 +9851,8 @@
       }
     }
     fromDOM(n) {
-      for (let i = 0, base2 = 0, domBase = 0; ; i++) {
-        let vp = i < this.viewports.length ? this.viewports[i] : null;
+      for (let i2 = 0, base2 = 0, domBase = 0; ; i2++) {
+        let vp = i2 < this.viewports.length ? this.viewports[i2] : null;
         if (!vp || n < vp.domTop)
           return base2 + (n - domBase) / this.scale;
         if (n <= vp.domBottom)
@@ -9864,7 +9864,7 @@
     eq(other) {
       if (!(other instanceof _BigScaler))
         return false;
-      return this.scale == other.scale && this.viewports.length == other.viewports.length && this.viewports.every((vp, i) => vp.from == other.viewports[i].from && vp.to == other.viewports[i].to);
+      return this.scale == other.scale && this.viewports.length == other.viewports.length && this.viewports.every((vp, i2) => vp.from == other.viewports[i2].from && vp.to == other.viewports[i2].to);
     }
   };
   function scaleBlock(block, scaler) {
@@ -10294,7 +10294,7 @@
       }, 500);
     }
     updateGaps(gaps) {
-      if (this.gapIntersection && (gaps.length != this.gaps.length || this.gaps.some((g, i) => g != gaps[i]))) {
+      if (this.gapIntersection && (gaps.length != this.gaps.length || this.gaps.some((g, i2) => g != gaps[i2]))) {
         this.gapIntersection.disconnect();
         for (let gap of gaps)
           this.gapIntersection.observe(gap);
@@ -10348,13 +10348,13 @@
     }
     listenForScroll() {
       this.parentCheck = -1;
-      let i = 0, changed = null;
+      let i2 = 0, changed = null;
       for (let dom = this.dom; dom; ) {
         if (dom.nodeType == 1) {
-          if (!changed && i < this.scrollTargets.length && this.scrollTargets[i] == dom)
-            i++;
+          if (!changed && i2 < this.scrollTargets.length && this.scrollTargets[i2] == dom)
+            i2++;
           else if (!changed)
-            changed = this.scrollTargets.slice(0, i);
+            changed = this.scrollTargets.slice(0, i2);
           if (changed)
             changed.push(dom);
           dom = dom.assignedSlot || dom.parentNode;
@@ -10364,8 +10364,8 @@
           break;
         }
       }
-      if (i < this.scrollTargets.length && !changed)
-        changed = this.scrollTargets.slice(0, i);
+      if (i2 < this.scrollTargets.length && !changed)
+        changed = this.scrollTargets.slice(0, i2);
       if (changed) {
         for (let dom of this.scrollTargets)
           dom.removeEventListener("scroll", this.onScroll);
@@ -10677,8 +10677,8 @@
       };
       this.handlers.characterboundsupdate = (e) => {
         let rects = [], prev = null;
-        for (let i = this.toEditorPos(e.rangeStart), end = this.toEditorPos(e.rangeEnd); i < end; i++) {
-          let rect = view.coordsForChar(i);
+        for (let i2 = this.toEditorPos(e.rangeStart), end = this.toEditorPos(e.rangeEnd); i2 < end; i2++) {
+          let rect = view.coordsForChar(i2);
           prev = rect && new DOMRect(rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top) || prev || new DOMRect();
           rects.push(prev);
         }
@@ -11101,8 +11101,8 @@
         for (let p of this.plugins)
           p.mustUpdate = update;
       }
-      for (let i = 0; i < this.plugins.length; i++)
-        this.plugins[i].update(this);
+      for (let i2 = 0; i2 < this.plugins.length; i2++)
+        this.plugins[i2].update(this);
       if (prevSpecs != specs)
         this.inputState.ensureHandlers(this.plugins);
     }
@@ -11141,7 +11141,7 @@
         scrollAnchorHeight = -1;
       this.viewState.scrollAnchorHeight = -1;
       try {
-        for (let i = 0; ; i++) {
+        for (let i2 = 0; ; i2++) {
           if (scrollAnchorHeight < 0) {
             if (isScrolledToBottom(scroll || this.win)) {
               scrollAnchorPos = -1;
@@ -11156,7 +11156,7 @@
           let changed = this.viewState.measure();
           if (!changed && !this.measureRequests.length && this.viewState.scrollTarget == null)
             break;
-          if (i > 5) {
+          if (i2 > 5) {
             console.warn(this.measureRequests.length ? "Measure loop restarted more than 5 times" : "Viewport failed to stabilize");
             break;
           }
@@ -11186,12 +11186,12 @@
             if (redrawn)
               this.docViewUpdate();
           }
-          for (let i2 = 0; i2 < measuring.length; i2++)
-            if (measured[i2] != BadMeasure) {
+          for (let i3 = 0; i3 < measuring.length; i3++)
+            if (measured[i3] != BadMeasure) {
               try {
-                let m = measuring[i2];
+                let m = measuring[i3];
                 if (m.write)
-                  m.write(measured[i2], this);
+                  m.write(measured[i3], this);
               } catch (e) {
                 logException(this.state, e);
               }
@@ -11302,9 +11302,9 @@
         if (this.measureRequests.indexOf(request) > -1)
           return;
         if (request.key != null)
-          for (let i = 0; i < this.measureRequests.length; i++) {
-            if (this.measureRequests[i].key === request.key) {
-              this.measureRequests[i] = request;
+          for (let i2 = 0; i2 < this.measureRequests.length; i2++) {
+            if (this.measureRequests[i2].key === request.key) {
+              this.measureRequests[i2] = request;
               return;
             }
           }
@@ -11772,11 +11772,11 @@
   EditorView.cursorScrollMargin = /* @__PURE__ */ Facet.define({
     combine: (inputs) => {
       let x = 5, y = 5;
-      for (let i of inputs) {
-        if (typeof i == "number")
-          x = y = i;
+      for (let i2 of inputs) {
+        if (typeof i2 == "number")
+          x = y = i2;
         else
-          ({ x, y } = i);
+          ({ x, y } = i2);
       }
       return { x, y };
     }
@@ -11803,8 +11803,8 @@
       if (changes.empty && !cache.some((c) => c.fresh))
         return cache;
       let result = [], lastDir = cache.length ? cache[cache.length - 1].dir : Direction.LTR;
-      for (let i = Math.max(0, cache.length - 10); i < cache.length; i++) {
-        let entry = cache[i];
+      for (let i2 = Math.max(0, cache.length - 10); i2 < cache.length; i2++) {
+        let entry = cache[i2];
         if (entry.dir == lastDir && !changes.touchesRange(entry.from, entry.to))
           result.push(new _CachedOrder(changes.mapPos(entry.from, 1), changes.mapPos(entry.to, -1), entry.dir, entry.isolates, false, entry.order));
       }
@@ -11812,8 +11812,8 @@
     }
   };
   function attrsFromFacet(view, facet, base2) {
-    for (let sources = view.state.facet(facet), i = sources.length - 1; i >= 0; i--) {
-      let source = sources[i], value = typeof source == "function" ? source(view) : source;
+    for (let sources = view.state.facet(facet), i2 = sources.length - 1; i2 >= 0; i2--) {
+      let source = sources[i2], value = typeof source == "function" ? source(view) : source;
       if (value)
         combineAttrs(value, base2);
     }
@@ -11826,8 +11826,8 @@
     if (result == "Space")
       result = " ";
     let alt, ctrl, shift2, meta2;
-    for (let i = 0; i < parts.length - 1; ++i) {
-      const mod = parts[i];
+    for (let i2 = 0; i2 < parts.length - 1; ++i2) {
+      const mod = parts[i2];
       if (/^(cmd|meta|m)$/i.test(mod))
         meta2 = true;
       else if (/^a(lt)?$/i.test(mod))
@@ -11898,8 +11898,8 @@
       var _a2, _b;
       let scopeObj = bound[scope] || (bound[scope] = /* @__PURE__ */ Object.create(null));
       let parts = key.split(/ (?!$)/).map((k) => normalizeKeyName(k, platform));
-      for (let i = 1; i < parts.length; i++) {
-        let prefix = parts.slice(0, i).join(" ");
+      for (let i2 = 1; i2 < parts.length; i2++) {
+        let prefix = parts.slice(0, i2).join(" ");
         checkPrefix(prefix, true);
         if (!scopeObj[prefix])
           scopeObj[prefix] = {
@@ -12112,8 +12112,8 @@
     }
     function pieces({ top: top2, bottom, horizontal }) {
       let pieces2 = [];
-      for (let i = 0; i < horizontal.length; i += 2)
-        pieces2.push(piece(horizontal[i], top2, horizontal[i + 1], bottom));
+      for (let i2 = 0; i2 < horizontal.length; i2 += 2)
+        pieces2.push(piece(horizontal[i2], top2, horizontal[i2 + 1], bottom));
       return pieces2;
     }
     function drawForLine(from2, to2, line) {
@@ -12210,7 +12210,7 @@
       }
     }
     draw(markers) {
-      if (markers.length != this.drawn.length || markers.some((p, i) => !sameMarker(p, this.drawn[i]))) {
+      if (markers.length != this.drawn.length || markers.some((p, i2) => !sameMarker(p, this.drawn[i2]))) {
         let old = this.dom.firstChild, oldI = 0;
         for (let marker of markers) {
           if (marker.update && old && marker.constructor && this.drawn[oldI].constructor && marker.update(old, this.drawn[oldI])) {
@@ -12605,15 +12605,15 @@
           regexp: conf.specialChars,
           decoration: (m, view, pos) => {
             let { doc: doc2 } = view.state;
-            let code = codePointAt2(m[0], 0);
-            if (code == 9) {
+            let code2 = codePointAt2(m[0], 0);
+            if (code2 == 9) {
               let line = doc2.lineAt(pos);
               let size = view.state.tabSize, col = countColumn(line.text, size, pos - line.from);
               return Decoration.replace({
                 widget: new TabWidget((size - col % size) * this.view.defaultCharacterWidth / this.view.scaleX)
               });
             }
-            return this.decorationCache[code] || (this.decorationCache[code] = Decoration.replace({ widget: new SpecialCharWidget(conf, code) }));
+            return this.decorationCache[code2] || (this.decorationCache[code2] = Decoration.replace({ widget: new SpecialCharWidget(conf, code2) }));
           },
           boundary: conf.replaceTabs ? void 0 : /[^]/
         });
@@ -12632,18 +12632,18 @@
     }));
   }
   var DefaultPlaceholder = "\u2022";
-  function placeholder$1(code) {
-    if (code >= 32)
+  function placeholder$1(code2) {
+    if (code2 >= 32)
       return DefaultPlaceholder;
-    if (code == 10)
+    if (code2 == 10)
       return "\u2424";
-    return String.fromCharCode(9216 + code);
+    return String.fromCharCode(9216 + code2);
   }
   var SpecialCharWidget = class extends WidgetType {
-    constructor(options, code) {
+    constructor(options, code2) {
       super();
       this.options = options;
-      this.code = code;
+      this.code = code2;
     }
     eq(other) {
       return other.code == this.code;
@@ -12716,15 +12716,15 @@
     let ranges = [];
     if (a.off > MaxOff || b.off > MaxOff || a.col < 0 || b.col < 0) {
       let startOff = Math.min(a.off, b.off), endOff = Math.max(a.off, b.off);
-      for (let i = startLine; i <= endLine; i++) {
-        let line = state.doc.line(i);
+      for (let i2 = startLine; i2 <= endLine; i2++) {
+        let line = state.doc.line(i2);
         if (line.length <= endOff)
           ranges.push(EditorSelection.range(line.from + startOff, line.to + endOff));
       }
     } else {
       let startCol = Math.min(a.col, b.col), endCol = Math.max(a.col, b.col);
-      for (let i = startLine; i <= endLine; i++) {
-        let line = state.doc.line(i);
+      for (let i2 = startLine; i2 <= endLine; i2++) {
+        let line = state.doc.line(i2);
         let start = findColumn(line.text, startCol, state.tabSize, true);
         if (start < 0) {
           ranges.push(EditorSelection.cursor(line.to));
@@ -12785,7 +12785,7 @@
   };
   var showCrosshair = { style: "cursor: crosshair" };
   function crosshairCursor(options = {}) {
-    let [code, getter] = keys[options.key || "Alt"];
+    let [code2, getter] = keys[options.key || "Alt"];
     let plugin = ViewPlugin.fromClass(class {
       constructor(view) {
         this.view = view;
@@ -12800,10 +12800,10 @@
     }, {
       eventObservers: {
         keydown(e) {
-          this.set(e.keyCode == code || getter(e));
+          this.set(e.keyCode == code2 || getter(e));
         },
         keyup(e) {
-          if (e.keyCode == code || !getter(e))
+          if (e.keyCode == code2 || !getter(e))
             this.set(false);
         },
         mousemove(e) {
@@ -12841,23 +12841,23 @@
         return false;
       }
       let tooltipViews = [], newAbove = above ? [] : null;
-      for (let i = 0; i < tooltips.length; i++) {
-        let tip = tooltips[i], known = -1;
+      for (let i2 = 0; i2 < tooltips.length; i2++) {
+        let tip = tooltips[i2], known = -1;
         if (!tip)
           continue;
-        for (let i2 = 0; i2 < this.tooltips.length; i2++) {
-          let other = this.tooltips[i2];
+        for (let i3 = 0; i3 < this.tooltips.length; i3++) {
+          let other = this.tooltips[i3];
           if (other && other.create == tip.create)
-            known = i2;
+            known = i3;
         }
         if (known < 0) {
-          tooltipViews[i] = this.createTooltipView(tip, i ? tooltipViews[i - 1] : null);
+          tooltipViews[i2] = this.createTooltipView(tip, i2 ? tooltipViews[i2 - 1] : null);
           if (newAbove)
-            newAbove[i] = !!tip.above;
+            newAbove[i2] = !!tip.above;
         } else {
-          let tooltipView = tooltipViews[i] = this.tooltipViews[known];
+          let tooltipView = tooltipViews[i2] = this.tooltipViews[known];
           if (newAbove)
-            newAbove[i] = above[known];
+            newAbove[i2] = above[known];
           if (tooltipView.update)
             tooltipView.update(update);
         }
@@ -12868,7 +12868,7 @@
           (_a2 = t2.destroy) === null || _a2 === void 0 ? void 0 : _a2.call(t2);
         }
       if (above) {
-        newAbove.forEach((val, i) => above[i] = val);
+        newAbove.forEach((val, i2) => above[i2] = val);
         above.length = newAbove.length;
       }
       this.input = input;
@@ -13036,8 +13036,8 @@
           bottom: visible.bottom - margins.bottom
         },
         parent: this.parent ? this.container.getBoundingClientRect() : this.view.dom.getBoundingClientRect(),
-        pos: this.manager.tooltips.map((t2, i) => {
-          let tv = this.manager.tooltipViews[i];
+        pos: this.manager.tooltips.map((t2, i2) => {
+          let tv = this.manager.tooltipViews[i2];
           return tv.getCoords ? tv.getCoords(t2.pos) : this.view.coordsAtPos(t2.pos);
         }),
         size: this.manager.tooltipViews.map(({ dom }) => dom.getBoundingClientRect()),
@@ -13057,9 +13057,9 @@
       }
       let { visible, space, scaleX, scaleY } = measured;
       let others = [];
-      for (let i = 0; i < this.manager.tooltips.length; i++) {
-        let tooltip = this.manager.tooltips[i], tView = this.manager.tooltipViews[i], { dom } = tView;
-        let pos = measured.pos[i], size = measured.size[i];
+      for (let i2 = 0; i2 < this.manager.tooltips.length; i2++) {
+        let tooltip = this.manager.tooltips[i2], tView = this.manager.tooltipViews[i2], { dom } = tView;
+        let pos = measured.pos[i2], size = measured.size[i2];
         if (!pos || tooltip.clip !== false && (pos.bottom <= Math.max(visible.top, space.top) || pos.top >= Math.min(visible.bottom, space.bottom) || pos.right < Math.max(visible.left, space.left) - 0.1 || pos.left > Math.min(visible.right, space.right) + 0.1)) {
           dom.style.top = Outside;
           continue;
@@ -13069,9 +13069,9 @@
         let width = size.right - size.left, height = (_a2 = knownHeight.get(tView)) !== null && _a2 !== void 0 ? _a2 : size.bottom - size.top;
         let offset = tView.offset || noOffset, ltr = this.view.textDirection == Direction.LTR;
         let left = size.width > space.right - space.left ? ltr ? space.left : space.right - size.width : ltr ? Math.max(space.left, Math.min(pos.left - (arrow ? 14 : 0) + offset.x, space.right - width)) : Math.min(Math.max(space.left, pos.left - width + (arrow ? 14 : 0) - offset.x), space.right - width);
-        let above = this.above[i];
+        let above = this.above[i2];
         if (!tooltip.strictSide && (above ? pos.top - height - arrowHeight - offset.y < space.top : pos.bottom + height + arrowHeight + offset.y > space.bottom) && above == space.bottom - pos.bottom > pos.top - space.top)
-          above = this.above[i] = !above;
+          above = this.above[i2] = !above;
         let spaceVert = (above ? pos.top - space.top : space.bottom - pos.bottom) - arrowHeight;
         if (spaceVert < height && tView.resize !== false) {
           if (spaceVert < this.view.defaultLineHeight) {
@@ -13200,7 +13200,7 @@
     enables: [tooltipPlugin, baseTheme]
   });
   var showHoverTooltip = /* @__PURE__ */ Facet.define({
-    combine: (inputs) => inputs.reduce((a, i) => a.concat(i), [])
+    combine: (inputs) => inputs.reduce((a, i2) => a.concat(i2), [])
   });
   var HoverTooltipHost = class _HoverTooltipHost {
     // Needs to be static so that host tooltip instances always match
@@ -13720,8 +13720,8 @@
       content2.appendChild(crelt("button", { class: "cm-button", type: "submit" }, config2.submitLabel || "OK"));
     }
     let forms = content2.nodeName == "FORM" ? [content2] : content2.querySelectorAll("form");
-    for (let i = 0; i < forms.length; i++) {
-      let form = forms[i];
+    for (let i2 = 0; i2 < forms.length; i2++) {
+      let form = forms[i2];
       form.addEventListener("keydown", (event) => {
         if (event.keyCode == 27) {
           event.preventDefault();
@@ -14105,9 +14105,9 @@
           let c = marker.elementClass;
           if (c)
             cls += " " + c;
-          for (let i = iOld; i < this.markers.length; i++)
-            if (this.markers[i].compare(marker)) {
-              skipTo = i;
+          for (let i2 = iOld; i2 < this.markers.length; i2++)
+            if (this.markers[i2].compare(marker)) {
+              skipTo = i2;
               matched = true;
               break;
             }
@@ -14144,8 +14144,8 @@
   function sameMarkers(a, b) {
     if (a.length != b.length)
       return false;
-    for (let i = 0; i < a.length; i++)
-      if (!a[i].compare(b[i]))
+    for (let i2 = 0; i2 < a.length; i2++)
+      if (!a[i2].compare(b[i2]))
         return false;
     return true;
   }
@@ -14399,8 +14399,8 @@
         for (let name2 of prop.split(" "))
           direct[name2] = map[prop];
       return (node) => {
-        for (let groups = node.prop(NodeProp.group), i = -1; i < (groups ? groups.length : 0); i++) {
-          let found = direct[i < 0 ? node.name : groups[i]];
+        for (let groups = node.prop(NodeProp.group), i2 = -1; i2 < (groups ? groups.length : 0); i2++) {
+          let found = direct[i2 < 0 ? node.name : groups[i2]];
           if (found)
             return found;
         }
@@ -14421,8 +14421,8 @@
     */
     constructor(types2) {
       this.types = types2;
-      for (let i = 0; i < types2.length; i++)
-        if (types2[i].id != i)
+      for (let i2 = 0; i2 < types2.length; i2++)
+        if (types2[i2].id != i2)
           throw new RangeError("Node type ids should correspond to array positions when creating a node set");
     }
     /**
@@ -14699,9 +14699,9 @@
     */
     findChild(startIndex, endIndex, dir, pos, side) {
       let { buffer } = this, pick = -1;
-      for (let i = startIndex; i != endIndex; i = buffer[i + 3]) {
-        if (checkSide(side, pos, buffer[i + 1], buffer[i + 2])) {
-          pick = i;
+      for (let i2 = startIndex; i2 != endIndex; i2 = buffer[i2 + 3]) {
+        if (checkSide(side, pos, buffer[i2 + 1], buffer[i2 + 2])) {
+          pick = i2;
           if (dir > 0)
             break;
         }
@@ -14714,11 +14714,11 @@
     slice(startI, endI, from) {
       let b = this.buffer;
       let copy = new Uint16Array(endI - startI), len = 0;
-      for (let i = startI, j = 0; i < endI; ) {
-        copy[j++] = b[i++];
-        copy[j++] = b[i++] - from;
-        let to = copy[j++] = b[i++] - from;
-        copy[j++] = b[i++] - startI;
+      for (let i2 = startI, j = 0; i2 < endI; ) {
+        copy[j++] = b[i2++];
+        copy[j++] = b[i2++] - from;
+        let to = copy[j++] = b[i2++] - from;
+        copy[j++] = b[i2++] - startI;
         len = Math.max(len, to);
       }
       return new _TreeBuffer(copy, len, this.set);
@@ -14820,10 +14820,10 @@
     get to() {
       return this.from + this._tree.length;
     }
-    nextChild(i, dir, pos, side, mode = 0) {
+    nextChild(i2, dir, pos, side, mode = 0) {
       for (let parent2 = this; ; ) {
-        for (let { children, positions } = parent2._tree, e = dir > 0 ? children.length : -1; i != e; i += dir) {
-          let next = children[i], start = positions[i] + parent2.from, mounted;
+        for (let { children, positions } = parent2._tree, e = dir > 0 ? children.length : -1; i2 != e; i2 += dir) {
+          let next = children[i2], start = positions[i2] + parent2.from, mounted;
           if (!(mode & IterMode.EnterBracketed && next instanceof Tree && (mounted = MountedTree.get(next)) && !mounted.overlay && mounted.bracketed && pos >= start && pos <= start + next.length) && !checkSide(side, pos, start, start + next.length))
             continue;
           if (next instanceof TreeBuffer) {
@@ -14831,21 +14831,21 @@
               continue;
             let index = next.findChild(0, next.buffer.length, dir, pos - start, side);
             if (index > -1)
-              return new BufferNode(new BufferContext(parent2, next, i, start), null, index);
+              return new BufferNode(new BufferContext(parent2, next, i2, start), null, index);
           } else if (mode & IterMode.IncludeAnonymous || (!next.type.isAnonymous || hasChild(next))) {
             let mounted2;
             if (!(mode & IterMode.IgnoreMounts) && (mounted2 = MountedTree.get(next)) && !mounted2.overlay)
-              return new _TreeNode(mounted2.tree, start, i, parent2);
-            let inner = new _TreeNode(next, start, i, parent2);
+              return new _TreeNode(mounted2.tree, start, i2, parent2);
+            let inner = new _TreeNode(next, start, i2, parent2);
             return mode & IterMode.IncludeAnonymous || !inner.type.isAnonymous ? inner : inner.nextChild(dir < 0 ? next.children.length - 1 : 0, dir, pos, side, mode);
           }
         }
         if (mode & IterMode.IncludeAnonymous || !parent2.type.isAnonymous)
           return null;
         if (parent2.index >= 0)
-          i = parent2.index + dir;
+          i2 = parent2.index + dir;
         else
-          i = dir < 0 ? -1 : parent2._parent._tree.children.length;
+          i2 = dir < 0 ? -1 : parent2._parent._tree.children.length;
         parent2 = parent2._parent;
         if (!parent2)
           return null;
@@ -14960,14 +14960,14 @@
         return after == null ? result : [];
     }
   }
-  function matchNodeContext(node, context, i = context.length - 1) {
-    for (let p = node; i >= 0; p = p.parent) {
+  function matchNodeContext(node, context, i2 = context.length - 1) {
+    for (let p = node; i2 >= 0; p = p.parent) {
       if (!p)
         return false;
       if (!p.type.isAnonymous) {
-        if (context[i] && context[i] != p.name)
+        if (context[i2] && context[i2] != p.name)
           return false;
-        i--;
+        i2--;
       }
     }
     return true;
@@ -15102,11 +15102,11 @@
     if (!heads.length)
       return null;
     let pick = 0, picked = heads[0];
-    for (let i = 1; i < heads.length; i++) {
-      let node = heads[i];
+    for (let i2 = 1; i2 < heads.length; i2++) {
+      let node = heads[i2];
       if (node.from > picked.from || node.to < picked.to) {
         picked = node;
-        pick = i;
+        pick = i2;
       }
     }
     let next = picked instanceof TreeNode && picked.index < 0 ? null : picked.parent;
@@ -15332,8 +15332,8 @@
           if (this.index < buffer.buffer.buffer.length)
             return false;
         } else {
-          for (let i = 0; i < this.index; i++)
-            if (buffer.buffer.buffer[i + 3] < this.index)
+          for (let i2 = 0; i2 < this.index; i2++)
+            if (buffer.buffer.buffer[i2 + 3] < this.index)
               return false;
         }
         ({ index, parent: parent2 } = buffer);
@@ -15342,8 +15342,8 @@
       }
       for (; parent2; { index, _parent: parent2 } = parent2) {
         if (index > -1)
-          for (let i = index + dir, e = dir < 0 ? -1 : parent2._tree.children.length; i != e; i += dir) {
-            let child = parent2._tree.children[i];
+          for (let i2 = index + dir, e = dir < 0 ? -1 : parent2._tree.children.length; i2 != e; i2 += dir) {
+            let child = parent2._tree.children[i2];
             if (this.mode & IterMode.IncludeAnonymous || child instanceof TreeBuffer || !child.type.isAnonymous || hasChild(child))
               return false;
           }
@@ -15418,8 +15418,8 @@
           index = this.stack[--d];
         }
       }
-      for (let i = depth; i < this.stack.length; i++)
-        result = new BufferNode(this.buffer, result, this.stack[i]);
+      for (let i2 = depth; i2 < this.stack.length; i2++)
+        result = new BufferNode(this.buffer, result, this.stack[i2]);
       return this.bufferNode = new BufferNode(this.buffer, result, this.index);
     }
     /**
@@ -15470,14 +15470,14 @@
       if (!this.buffer)
         return matchNodeContext(this.node.parent, context);
       let { buffer } = this.buffer, { types: types2 } = buffer.set;
-      for (let i = context.length - 1, d = this.stack.length - 1; i >= 0; d--) {
+      for (let i2 = context.length - 1, d = this.stack.length - 1; i2 >= 0; d--) {
         if (d < 0)
-          return matchNodeContext(this._tree, context, i);
+          return matchNodeContext(this._tree, context, i2);
         let type = types2[buffer.buffer[this.stack[d]]];
         if (!type.isAnonymous) {
-          if (context[i] && context[i] != type.name)
+          if (context[i2] && context[i2] != type.name)
             return false;
-          i--;
+          i2--;
         }
       }
       return true;
@@ -15575,10 +15575,10 @@
       if (nodeCount) {
         let buffer2 = new Uint16Array(nodeCount * 4);
         let start = nodes[nodes.length - 2];
-        for (let i = nodes.length - 3, j = 0; i >= 0; i -= 3) {
-          buffer2[j++] = nodes[i];
-          buffer2[j++] = nodes[i + 1] - start;
-          buffer2[j++] = nodes[i + 2] - start;
+        for (let i2 = nodes.length - 3, j = 0; i2 >= 0; i2 -= 3) {
+          buffer2[j++] = nodes[i2];
+          buffer2[j++] = nodes[i2 + 1] - start;
+          buffer2[j++] = nodes[i2 + 2] - start;
           buffer2[j++] = j;
         }
         children2.push(new TreeBuffer(buffer2, nodes[2] - start, nodeSet2));
@@ -15597,9 +15597,9 @@
         return makeTree(type, children2, positions2, length2, lookAhead2, contextHash2);
       };
     }
-    function makeRepeatLeaf(children2, positions2, base2, i, from, to, type, lookAhead2, contextHash2) {
+    function makeRepeatLeaf(children2, positions2, base2, i2, from, to, type, lookAhead2, contextHash2) {
       let localChildren = [], localPositions = [];
-      while (children2.length > i) {
+      while (children2.length > i2) {
         localChildren.push(children2.pop());
         localPositions.push(positions2.pop() + base2 - from);
       }
@@ -15707,24 +15707,24 @@
   }
   function balanceRange(balanceType, children, positions, from, to, start, length, mkTop, mkTree) {
     let total = 0;
-    for (let i = from; i < to; i++)
-      total += nodeSize(balanceType, children[i]);
+    for (let i2 = from; i2 < to; i2++)
+      total += nodeSize(balanceType, children[i2]);
     let maxChild = Math.ceil(
       total * 1.5 / 8
       /* Balance.BranchFactor */
     );
     let localChildren = [], localPositions = [];
     function divide(children2, positions2, from2, to2, offset) {
-      for (let i = from2; i < to2; ) {
-        let groupFrom = i, groupStart = positions2[i], groupSize = nodeSize(balanceType, children2[i]);
-        i++;
-        for (; i < to2; i++) {
-          let nextSize = nodeSize(balanceType, children2[i]);
+      for (let i2 = from2; i2 < to2; ) {
+        let groupFrom = i2, groupStart = positions2[i2], groupSize = nodeSize(balanceType, children2[i2]);
+        i2++;
+        for (; i2 < to2; i2++) {
+          let nextSize = nodeSize(balanceType, children2[i2]);
           if (groupSize + nextSize >= maxChild)
             break;
           groupSize += nextSize;
         }
-        if (i == groupFrom + 1) {
+        if (i2 == groupFrom + 1) {
           if (groupSize > maxChild) {
             let only = children2[groupFrom];
             divide(only.children, only.positions, 0, only.children.length, positions2[groupFrom] + offset);
@@ -15732,8 +15732,8 @@
           }
           localChildren.push(children2[groupFrom]);
         } else {
-          let length2 = positions2[i - 1] + children2[i - 1].length - groupStart;
-          localChildren.push(balanceRange(balanceType, children2, positions2, groupFrom, i, groupStart, length2, null, mkTree));
+          let length2 = positions2[i2 - 1] + children2[i2 - 1].length - groupStart;
+          localChildren.push(balanceRange(balanceType, children2, positions2, groupFrom, i2, groupStart, length2, null, mkTree));
         }
         localPositions.push(groupStart + offset - start);
       }
@@ -15947,13 +15947,13 @@
     }
   };
   function sameArray2(a, b) {
-    return a.length == b.length && a.every((x, i) => x == b[i]);
+    return a.length == b.length && a.every((x, i2) => x == b[i2]);
   }
   function powerSet(array) {
     let sets = [[]];
-    for (let i = 0; i < array.length; i++) {
+    for (let i2 = 0; i2 < array.length; i2++) {
       for (let j = 0, e = sets.length; j < e; j++) {
-        sets.push(sets[j].concat(array[i]));
+        sets.push(sets[j].concat(array[i2]));
       }
     }
     return sets.sort((a, b) => b.length - a.length);
@@ -16130,8 +16130,8 @@
         let inner = cursor2.node.enter(mounted.overlay[0].from + start, 1);
         let innerHighlighters = this.highlighters.filter((h) => !h.scope || h.scope(mounted.tree.type));
         let hasChild2 = cursor2.firstChild();
-        for (let i = 0, pos = start; ; i++) {
-          let next = i < mounted.overlay.length ? mounted.overlay[i] : null;
+        for (let i2 = 0, pos = start; ; i2++) {
+          let next = i2 < mounted.overlay.length ? mounted.overlay[i2] : null;
           let nextPos = next ? next.from + start : end;
           let rangeFrom2 = Math.max(from, pos), rangeTo2 = Math.min(to, nextPos);
           if (rangeFrom2 < rangeTo2 && hasChild2) {
@@ -16675,10 +16675,10 @@
               return;
           }
         }
-        for (let i = 0; i < tree.children.length; i++) {
-          let ch = tree.children[i];
+        for (let i2 = 0; i2 < tree.children.length; i2++) {
+          let ch = tree.children[i2];
           if (ch instanceof Tree)
-            explore(ch, tree.positions[i] + from);
+            explore(ch, tree.positions[i2] + from);
         }
       };
       explore(syntaxTree(state), 0);
@@ -16863,11 +16863,11 @@
         return false;
       this.viewport = viewport;
       let startLen = this.skipped.length;
-      for (let i = 0; i < this.skipped.length; i++) {
-        let { from, to } = this.skipped[i];
+      for (let i2 = 0; i2 < this.skipped.length; i2++) {
+        let { from, to } = this.skipped[i2];
         if (from < viewport.to && to > viewport.from) {
           this.fragments = cutFragments(this.fragments, from, to);
-          this.skipped.splice(i--, 1);
+          this.skipped.splice(i2--, 1);
         }
       }
       if (this.skipped.length >= startLen)
@@ -17114,7 +17114,7 @@
       }
       ch = " ";
     }
-    for (let i = 0; i < cols; i++)
+    for (let i2 = 0; i2 < cols; i2++)
       result += ch;
     return result;
   }
@@ -17217,8 +17217,8 @@
       let add2 = [];
       for (let cur2 = inner; cur2 && !(cur2.from < stack.node.from || cur2.to > stack.node.to || cur2.from == stack.node.from && cur2.type == stack.node.type); cur2 = cur2.parent)
         add2.push(cur2);
-      for (let i = add2.length - 1; i >= 0; i--)
-        stack = { node: add2[i], next: stack };
+      for (let i2 = add2.length - 1; i2 >= 0; i2--)
+        stack = { node: add2[i2], next: stack };
     }
     return indentFor(stack, cx, pos);
   }
@@ -17461,8 +17461,8 @@
       if (!Array.isArray(value) || value.length % 2)
         throw new RangeError("Invalid JSON for fold state");
       let ranges = [];
-      for (let i = 0; i < value.length; ) {
-        let from = value[i++], to = value[i++];
+      for (let i2 = 0; i2 < value.length; ) {
+        let from = value[i2++], to = value[i2++];
         if (typeof from != "number" || typeof to != "number")
           throw new RangeError("Invalid JSON for fold state");
         ranges.push(foldWidget.range(from, to));
@@ -18044,8 +18044,8 @@
         end = string2.length;
     }
     let n = startValue;
-    for (let i = startIndex; i < end; i++) {
-      if (string2.charCodeAt(i) == 9)
+    for (let i2 = startIndex; i2 < end; i2++) {
+      if (string2.charCodeAt(i2) == 9)
         n += tabSize - n % tabSize;
       else
         n++;
@@ -18301,8 +18301,8 @@
     let state = off >= startPos && off + tree.length <= before && tree.prop(lang.stateAfter);
     if (state)
       return { state: lang.streamParser.copyState(state), pos: off + tree.length };
-    for (let i = tree.children.length - 1; i >= 0; i--) {
-      let child = tree.children[i], pos = off + tree.positions[i];
+    for (let i2 = tree.children.length - 1; i2 >= 0; i2--) {
+      let child = tree.children[i2], pos = off + tree.positions[i2];
       let found = child instanceof Tree && pos < before && findState(lang, child, pos, startPos, before);
       if (found)
         return found;
@@ -18314,12 +18314,12 @@
       return tree;
     if (!inside && from == 0 && tree.type == lang.topNode)
       inside = true;
-    for (let i = tree.children.length - 1; i >= 0; i--) {
-      let pos = tree.positions[i], child = tree.children[i], inner;
+    for (let i2 = tree.children.length - 1; i2 >= 0; i2--) {
+      let pos = tree.positions[i2], child = tree.children[i2], inner;
       if (pos < to && child instanceof Tree) {
         if (!(inner = cutTree(lang, child, from - pos, to - pos, inside)))
           break;
-        return !inside ? inner : new Tree(tree.type, tree.children.slice(0, i).concat(inner), tree.positions.slice(0, i + 1), pos + inner.length);
+        return !inside ? inner : new Tree(tree.type, tree.children.slice(0, i2).concat(inner), tree.positions.slice(0, i2 + 1), pos + inner.length);
       }
     }
     return null;
@@ -18350,9 +18350,9 @@
       let { state, tree } = findStartInFragments(lang, fragments, from, this.to, context === null || context === void 0 ? void 0 : context.state);
       this.state = state;
       this.parsedPos = this.chunkStart = from + tree.length;
-      for (let i = 0; i < tree.children.length; i++) {
-        this.chunks.push(tree.children[i]);
-        this.chunkPos.push(tree.positions[i]);
+      for (let i2 = 0; i2 < tree.children.length; i2++) {
+        this.chunks.push(tree.children[i2]);
+        this.chunkPos.push(tree.positions[i2]);
       }
       if (context && this.parsedPos < context.viewport.from - 1e5 && ranges.some((r) => r.from <= context.viewport.from && r.to >= context.viewport.from)) {
         this.state = this.lang.streamParser.startState(getIndentUnit(context.state));
@@ -18487,7 +18487,7 @@
   };
   function readToken(token, stream, state) {
     stream.start = stream.pos;
-    for (let i = 0; i < 10; i++) {
+    for (let i2 = 0; i2 < 10; i2++) {
       let result = token(stream, state);
       if (stream.pos > stream.start)
         return result;
@@ -18671,18 +18671,18 @@
     let tokens = ranges.map((r) => getConfig(state, r.from).block);
     if (!tokens.every((c) => c))
       return null;
-    let comments = ranges.map((r, i) => findBlockComment(state, tokens[i], r.from, r.to));
+    let comments = ranges.map((r, i2) => findBlockComment(state, tokens[i2], r.from, r.to));
     if (option != 2 && !comments.every((c) => c)) {
-      return { changes: state.changes(ranges.map((range, i) => {
-        if (comments[i])
+      return { changes: state.changes(ranges.map((range, i2) => {
+        if (comments[i2])
           return [];
-        return [{ from: range.from, insert: tokens[i].open + " " }, { from: range.to, insert: " " + tokens[i].close }];
+        return [{ from: range.from, insert: tokens[i2].open + " " }, { from: range.to, insert: " " + tokens[i2].close }];
       })) };
     } else if (option != 1 && comments.some((c) => c)) {
       let changes = [];
-      for (let i = 0, comment2; i < comments.length; i++)
-        if (comment2 = comments[i]) {
-          let token = tokens[i], { open, close } = comment2;
+      for (let i2 = 0, comment2; i2 < comments.length; i2++)
+        if (comment2 = comments[i2]) {
+          let token = tokens[i2], { open, close } = comment2;
           changes.push({ from: open.pos - token.open.length, to: open.pos + open.margin }, { from: close.pos - close.margin, to: close.pos + token.close.length });
         }
       return { changes };
@@ -18713,9 +18713,9 @@
         pos = line.to + 1;
       }
       if (minIndent < 1e9) {
-        for (let i = startI; i < lines.length; i++)
-          if (lines[i].indent < lines[i].line.text.length)
-            lines[i].indent = minIndent;
+        for (let i2 = startI; i2 < lines.length; i2++)
+          if (lines[i2].indent < lines[i2].line.text.length)
+            lines[i2].indent = minIndent;
       }
       if (lines.length == startI + 1)
         lines[startI].single = true;
@@ -18878,8 +18878,8 @@
     let ranges = [], isAdjacent2 = false;
     a.iterChangedRanges((f, t2) => ranges.push(f, t2));
     b.iterChangedRanges((_f, _t, f, t2) => {
-      for (let i = 0; i < ranges.length; ) {
-        let from = ranges[i++], to = ranges[i++];
+      for (let i2 = 0; i2 < ranges.length; ) {
+        let from = ranges[i2++], to = ranges[i2++];
         if (t2 >= from && f <= to)
           isAdjacent2 = true;
       }
@@ -18887,7 +18887,7 @@
     return isAdjacent2;
   }
   function eqSelectionShape(a, b) {
-    return a.ranges.length == b.ranges.length && a.ranges.filter((r, i) => r.empty != b.ranges[i].empty).length === 0;
+    return a.ranges.length == b.ranges.length && a.ranges.filter((r, i2) => r.empty != b.ranges[i2].empty).length === 0;
   }
   function conc(a, b) {
     return !a.length ? b : !b.length ? a : a.concat(b);
@@ -19313,7 +19313,7 @@
       if (before[before.length - 1] == "	")
         return pos - 1;
       let col = countColumn(before, state.tabSize), drop = col % getIndentUnit(state) || getIndentUnit(state);
-      for (let i = 0; i < drop && before[before.length - 1 - i] == " "; i++)
+      for (let i2 = 0; i2 < drop && before[before.length - 1 - i2] == " "; i2++)
         pos--;
       targetPos = pos;
     } else {
@@ -19728,27 +19728,27 @@
         this.bufferPos += codePointSize2(next);
         let norm = this.normalize(str);
         if (norm.length)
-          for (let i = 0, pos = start, posPrecise = true; ; i++) {
-            let code = norm.charCodeAt(i);
-            let match = this.match(code, pos, posPrecise, this.bufferPos + this.bufferStart, i == norm.length - 1);
+          for (let i2 = 0, pos = start, posPrecise = true; ; i2++) {
+            let code2 = norm.charCodeAt(i2);
+            let match = this.match(code2, pos, posPrecise, this.bufferPos + this.bufferStart, i2 == norm.length - 1);
             if (match) {
               this.value = match;
               return this;
             }
-            if (i == norm.length - 1)
+            if (i2 == norm.length - 1)
               break;
-            if (posPrecise && i < str.length && str.charCodeAt(i) == code)
+            if (posPrecise && i2 < str.length && str.charCodeAt(i2) == code2)
               pos++;
             else
               posPrecise = false;
           }
       }
     }
-    match(code, pos, posPrecise, end, endPrecise) {
+    match(code2, pos, posPrecise, end, endPrecise) {
       let match = null;
-      for (let i = 0; i < this.matches.length; ) {
-        let partial = this.matches[i], keep = false;
-        if (this.query.charCodeAt(partial.index) == code) {
+      for (let i2 = 0; i2 < this.matches.length; ) {
+        let partial = this.matches[i2], keep = false;
+        if (this.query.charCodeAt(partial.index) == code2) {
           if (partial.index == this.query.length - 1) {
             match = { from: partial.from, to: end, precise: endPrecise && partial.precise };
           } else {
@@ -19757,11 +19757,11 @@
           }
         }
         if (keep)
-          i++;
+          i2++;
         else
-          this.matches.splice(i, 1);
+          this.matches.splice(i2, 1);
       }
-      if (this.query.charCodeAt(0) == code) {
+      if (this.query.charCodeAt(0) == code2) {
         if (this.query.length == 1)
           match = { from: pos, to: end, precise: posPrecise && endPrecise };
         else
@@ -20295,15 +20295,15 @@
       return this.prevMatchInRange(state, 0, curFrom) || this.prevMatchInRange(state, curTo, state.doc.length);
     }
     getReplacement(result) {
-      return this.spec.unquote(this.spec.replace).replace(/\$([$&]|\d+)/g, (m, i) => {
-        if (i == "&")
+      return this.spec.unquote(this.spec.replace).replace(/\$([$&]|\d+)/g, (m, i2) => {
+        if (i2 == "&")
           return result.match[0];
-        if (i == "$")
+        if (i2 == "$")
           return "$";
-        for (let l = i.length; l > 0; l--) {
-          let n = +i.slice(0, l);
+        for (let l = i2.length; l > 0; l--) {
+          let n = +i2.slice(0, l);
           if (n > 0 && n < result.match.length)
-            return result.match[n] + i.slice(l);
+            return result.match[n] + i2.slice(l);
         }
         return m;
       });
@@ -20367,10 +20367,10 @@
         return Decoration.none;
       let { view } = this;
       let builder = new RangeSetBuilder();
-      for (let i = 0, ranges = view.visibleRanges, l = ranges.length; i < l; i++) {
-        let { from, to } = ranges[i];
-        while (i < l - 1 && to > ranges[i + 1].from - 2 * 250)
-          to = ranges[++i].to;
+      for (let i2 = 0, ranges = view.visibleRanges, l = ranges.length; i2 < l; i2++) {
+        let { from, to } = ranges[i2];
+        while (i2 < l - 1 && to > ranges[i2 + 1].from - 2 * 250)
+          to = ranges[++i2].to;
         query.highlight(view.state, from, to, (from2, to2) => {
           let selected = view.state.selection.ranges.some((r) => r.from == from2 && r.to == to2);
           builder.add(from2, to2, selected ? selectedMatchMark : matchMark);
@@ -20692,16 +20692,16 @@
     let start = Math.max(line.from, from - AnnounceMargin), end = Math.min(lineEnd, to + AnnounceMargin);
     let text = view.state.sliceDoc(start, end);
     if (start != line.from) {
-      for (let i = 0; i < AnnounceMargin; i++)
-        if (!Break.test(text[i + 1]) && Break.test(text[i])) {
-          text = text.slice(i);
+      for (let i2 = 0; i2 < AnnounceMargin; i2++)
+        if (!Break.test(text[i2 + 1]) && Break.test(text[i2])) {
+          text = text.slice(i2);
           break;
         }
     }
     if (end != lineEnd) {
-      for (let i = text.length - 1; i > text.length - AnnounceMargin; i--)
-        if (!Break.test(text[i - 1]) && Break.test(text[i])) {
-          text = text.slice(0, i);
+      for (let i2 = text.length - 1; i2 > text.length - AnnounceMargin; i2--)
+        if (!Break.test(text[i2 - 1]) && Break.test(text[i2])) {
+          text = text.slice(0, i2);
           break;
         }
     }
@@ -20823,8 +20823,8 @@
     let first = /* @__PURE__ */ Object.create(null), rest = /* @__PURE__ */ Object.create(null);
     for (let { label } of options) {
       first[label[0]] = true;
-      for (let i = 1; i < label.length; i++)
-        rest[label[i]] = true;
+      for (let i2 = 1; i2 < label.length; i2++)
+        rest[label[i2]] = true;
     }
     let source = toSet(first) + toSet(rest) + "*$";
     return [new RegExp("^" + source), new RegExp(source)];
@@ -20936,11 +20936,11 @@
         return this.ret(word.length == this.pattern.length ? 0 : -100, [0, this.pattern.length]);
       let len = chars.length, anyTo = 0;
       if (direct < 0) {
-        for (let i = 0, e = Math.min(word.length, 200); i < e && anyTo < len; ) {
-          let next = codePointAt2(word, i);
+        for (let i2 = 0, e = Math.min(word.length, 200); i2 < e && anyTo < len; ) {
+          let next = codePointAt2(word, i2);
           if (next == chars[anyTo] || next == folded[anyTo])
-            any[anyTo++] = i;
-          i += codePointSize2(next);
+            any[anyTo++] = i2;
+          i2 += codePointSize2(next);
         }
         if (anyTo < len)
           return null;
@@ -20949,16 +20949,16 @@
       let byWordTo = 0, byWordFolded = false;
       let adjacentTo = 0, adjacentStart = -1, adjacentEnd = -1;
       let hasLower = /[a-z]/.test(word), wordAdjacent = true;
-      for (let i = 0, e = Math.min(word.length, 200), prevType = 0; i < e && byWordTo < len; ) {
-        let next = codePointAt2(word, i);
+      for (let i2 = 0, e = Math.min(word.length, 200), prevType = 0; i2 < e && byWordTo < len; ) {
+        let next = codePointAt2(word, i2);
         if (direct < 0) {
           if (preciseTo < len && next == chars[preciseTo])
-            precise[preciseTo++] = i;
+            precise[preciseTo++] = i2;
           if (adjacentTo < len) {
             if (next == chars[adjacentTo] || next == folded[adjacentTo]) {
               if (adjacentTo == 0)
-                adjacentStart = i;
-              adjacentEnd = i + 1;
+                adjacentStart = i2;
+              adjacentEnd = i2 + 1;
               adjacentTo++;
             } else {
               adjacentTo = 0;
@@ -20966,14 +20966,14 @@
           }
         }
         let ch, type = next < 255 ? next >= 48 && next <= 57 || next >= 97 && next <= 122 ? 2 : next >= 65 && next <= 90 ? 1 : 0 : (ch = fromCodePoint(next)) != ch.toLowerCase() ? 1 : ch != ch.toUpperCase() ? 2 : 0;
-        if (!i || type == 1 && hasLower || prevType == 0 && type != 0) {
+        if (!i2 || type == 1 && hasLower || prevType == 0 && type != 0) {
           if (chars[byWordTo] == next || folded[byWordTo] == next && (byWordFolded = true))
-            byWord[byWordTo++] = i;
+            byWord[byWordTo++] = i2;
           else if (byWord.length)
             wordAdjacent = false;
         }
         prevType = type;
-        i += codePointSize2(next);
+        i2 += codePointSize2(next);
       }
       if (byWordTo == len && byWord[0] == 0 && wordAdjacent)
         return this.result(-100 + (byWordFolded ? -200 : 0), byWord, word);
@@ -20988,14 +20988,14 @@
       return chars.length == 2 ? null : this.result((any[0] ? -700 : 0) + -200 + -1100, any, word);
     }
     result(score2, positions, word) {
-      let result = [], i = 0;
+      let result = [], i2 = 0;
       for (let pos of positions) {
         let to = pos + (this.astral ? codePointSize2(codePointAt2(word, pos)) : 1);
-        if (i && result[i - 1] == pos)
-          result[i - 1] = to;
+        if (i2 && result[i2 - 1] == pos)
+          result[i2 - 1] = to;
         else {
-          result[i++] = pos;
-          result[i++] = to;
+          result[i2++] = pos;
+          result[i2++] = to;
         }
       }
       return this.ret(score2 - word.length, result);
@@ -21286,10 +21286,10 @@
     }
     updateSelectedOption(selected) {
       let set = null;
-      for (let opt = this.list.firstChild, i = this.range.from; opt; opt = opt.nextSibling, i++) {
+      for (let opt = this.list.firstChild, i2 = this.range.from; opt; opt = opt.nextSibling, i2++) {
         if (opt.nodeName != "LI" || !opt.id) {
-          i--;
-        } else if (i == selected) {
+          i2--;
+        } else if (i2 == selected) {
           if (!opt.hasAttribute("aria-selected")) {
             opt.setAttribute("aria-selected", "true");
             set = opt;
@@ -21343,11 +21343,11 @@
           e.preventDefault();
       });
       let curSection = null;
-      for (let i = range.from; i < range.to; i++) {
-        let { completion, match } = options[i], { section } = completion;
+      for (let i2 = range.from; i2 < range.to; i2++) {
+        let { completion, match } = options[i2], { section } = completion;
         if (section) {
           let name2 = typeof section == "string" ? section : section.name;
-          if (name2 != curSection && (i > range.from || range.from == 0)) {
+          if (name2 != curSection && (i2 > range.from || range.from == 0)) {
             curSection = name2;
             if (typeof section != "string" && section.header) {
               ul.appendChild(section.header(section));
@@ -21358,7 +21358,7 @@
           }
         }
         const li = ul.appendChild(document.createElement("li"));
-        li.id = id + "-" + i;
+        li.id = id + "-" + i2;
         li.setAttribute("role", "option");
         let cls = this.optionClass(completion);
         if (cls)
@@ -21489,9 +21489,9 @@
       let selected = state.facet(completionConfig).selectOnOpen ? 0 : -1;
       if (prev && prev.selected != selected && prev.selected != -1) {
         let selectedValue = prev.options[prev.selected].completion;
-        for (let i = 0; i < options.length; i++)
-          if (options[i].completion == selectedValue) {
-            selected = i;
+        for (let i2 = 0; i2 < options.length; i2++)
+          if (options[i2].completion == selectedValue) {
+            selected = i2;
             break;
           }
       }
@@ -21531,7 +21531,7 @@
         );
         return value.update(tr, conf);
       });
-      if (active.length == this.active.length && active.every((a, i) => a == this.active[i]))
+      if (active.length == this.active.length && active.every((a, i2) => a == this.active[i2]))
         active = this.active;
       let open = this.open, didSet = tr.effects.some((e) => e.is(setActiveEffect));
       if (open && tr.docChanged)
@@ -21811,8 +21811,8 @@
         let type = getUpdateType(tr, conf);
         return type & 8 || (tr.selection || tr.docChanged) && !(type & 3);
       });
-      for (let i = 0; i < this.running.length; i++) {
-        let query = this.running[i];
+      for (let i2 = 0; i2 < this.running.length; i2++) {
+        let query = this.running[i2];
         if (doesReset || query.context.abortOnDocChange && update.docChanged || query.updates.length + update.transactions.length > MaxUpdateCount && Date.now() - query.time > MinAbortTime) {
           for (let handler of query.context.abortListeners) {
             try {
@@ -21822,7 +21822,7 @@
             }
           }
           query.context.abortListeners = null;
-          this.running.splice(i--, 1);
+          this.running.splice(i2--, 1);
         } else {
           query.updates.push(...update.transactions);
         }
@@ -21882,11 +21882,11 @@
       this.debounceAccept = -1;
       let updated = [];
       let conf = this.view.state.facet(completionConfig), cState = this.view.state.field(completionState);
-      for (let i = 0; i < this.running.length; i++) {
-        let query = this.running[i];
+      for (let i2 = 0; i2 < this.running.length; i2++) {
+        let query = this.running[i2];
         if (query.done === void 0)
           continue;
-        this.running.splice(i--, 1);
+        this.running.splice(i2--, 1);
         if (query.done) {
           let pos = cur(query.updates.length ? query.updates[0].startState : this.view.state);
           let limit = Math.min(pos, query.done.from + (query.active.explicit ? 0 : 1));
@@ -22114,9 +22114,9 @@
   }
   var definedClosing = "()[]{}<>\xAB\xBB\xBB\xAB\uFF3B\uFF3D\uFF5B\uFF5D";
   function closing(ch) {
-    for (let i = 0; i < definedClosing.length; i += 2)
-      if (definedClosing.charCodeAt(i) == ch)
-        return definedClosing.charAt(i + 1);
+    for (let i2 = 0; i2 < definedClosing.length; i2 += 2)
+      if (definedClosing.charCodeAt(i2) == ch)
+        return definedClosing.charAt(i2 + 1);
     return fromCodePoint(ch < 128 ? ch : ch + 1);
   }
   function config(state, pos) {
@@ -22277,7 +22277,7 @@
   function probablyInString(state, pos, quoteToken, prefixes) {
     let node = syntaxTree(state).resolveInner(pos, -1);
     let maxPrefix = prefixes.reduce((m, p) => Math.max(m, p.length), 0);
-    for (let i = 0; i < 5; i++) {
+    for (let i2 = 0; i2 < 5; i2++) {
       let start = state.sliceDoc(node.from, Math.min(node.to, node.from + quoteToken.length + maxPrefix));
       let quotePos = start.indexOf(quoteToken);
       if (!quotePos || quotePos > -1 && prefixes.indexOf(start.slice(0, quotePos)) > -1) {
@@ -22351,8 +22351,8 @@
       let sorted = diagnostics.slice().sort((a, b) => a.from - b.from || a.to - b.to);
       let deco = new RangeSetBuilder(), active = [], pos = 0;
       let scan = state.doc.iter(), scanPos = 0, docLen = state.doc.length;
-      for (let i = 0; ; ) {
-        let next = i == sorted.length ? null : sorted[i];
+      for (let i2 = 0; ; ) {
+        let next = i2 == sorted.length ? null : sorted[i2];
         if (!next && !active.length)
           break;
         let from, to;
@@ -22365,13 +22365,13 @@
             break;
           to = next.to;
           active.push(next);
-          i++;
+          i2++;
         }
-        while (i < sorted.length) {
-          let next2 = sorted[i];
+        while (i2 < sorted.length) {
+          let next2 = sorted[i2];
           if (next2.from == from && (next2.to > next2.from || next2.to == from)) {
             active.push(next2);
-            i++;
+            i2++;
             to = Math.min(next2.to, to);
           } else {
             to = Math.min(next2.from, to);
@@ -22418,9 +22418,9 @@
         pos = to;
         if (pos == docLen)
           break;
-        for (let i2 = 0; i2 < active.length; i2++)
-          if (active[i2].to <= pos)
-            active.splice(i2--, 1);
+        for (let i3 = 0; i3 < active.length; i3++)
+          if (active[i3].to <= pos)
+            active.splice(i3--, 1);
       }
       let set = deco.finish();
       return new _LintState(set, panel, findDiagnostic(set));
@@ -22555,8 +22555,8 @@
   var lintConfig = /* @__PURE__ */ Facet.define({
     combine(input) {
       return {
-        sources: input.map((i) => i.source).filter((x) => x != null),
-        ...combineConfig(input.map((i) => i.config), {
+        sources: input.map((i2) => i2.source).filter((x) => x != null),
+        ...combineConfig(input.map((i2) => i2.config), {
           delay: 750,
           markerFilter: null,
           tooltipFilter: null,
@@ -22580,8 +22580,8 @@
     let assigned = [];
     if (actions)
       actions: for (let { name: name2 } of actions) {
-        for (let i = 0; i < name2.length; i++) {
-          let ch = name2[i];
+        for (let i2 = 0; i2 < name2.length; i2++) {
+          let ch = name2[i2];
           if (/[a-zA-Z]/.test(ch) && !assigned.some((c) => c.toLowerCase() == ch.toLowerCase())) {
             assigned.push(ch);
             continue actions;
@@ -22594,7 +22594,7 @@
   function renderDiagnostic(view, diagnostic, inPanel) {
     var _a2;
     let keys2 = inPanel ? assignKeys(diagnostic.actions) : [];
-    return crelt("li", { class: "cm-diagnostic cm-diagnostic-" + diagnostic.severity }, crelt("span", { class: "cm-diagnosticText" }, diagnostic.renderMessage ? diagnostic.renderMessage(view) : diagnostic.message), (_a2 = diagnostic.actions) === null || _a2 === void 0 ? void 0 : _a2.map((action, i) => {
+    return crelt("li", { class: "cm-diagnostic cm-diagnostic-" + diagnostic.severity }, crelt("span", { class: "cm-diagnosticText" }, diagnostic.renderMessage ? diagnostic.renderMessage(view) : diagnostic.message), (_a2 = diagnostic.actions) === null || _a2 === void 0 ? void 0 : _a2.map((action, i2) => {
       let fired = false, click = (e) => {
         e.preventDefault();
         if (fired)
@@ -22604,7 +22604,7 @@
         if (found)
           action.apply(view, found.from, found.to);
       };
-      let { name: name2 } = action, keyIndex = keys2[i] ? name2.indexOf(keys2[i]) : -1;
+      let { name: name2 } = action, keyIndex = keys2[i2] ? name2.indexOf(keys2[i2]) : -1;
       let nameElt = keyIndex < 0 ? name2 : [
         name2.slice(0, keyIndex),
         crelt("u", name2.slice(keyIndex, keyIndex + 1)),
@@ -22616,7 +22616,7 @@
         class: "cm-diagnosticAction" + markClass,
         onclick: click,
         onmousedown: click,
-        "aria-label": ` Action: ${name2}${keyIndex < 0 ? "" : ` (access key "${keys2[i]})"`}.`
+        "aria-label": ` Action: ${name2}${keyIndex < 0 ? "" : ` (access key "${keys2[i2]})"`}.`
       }, nameElt);
     }), diagnostic.source && crelt("div", { class: "cm-diagnosticSource" }, diagnostic.source));
   }
@@ -22663,11 +22663,11 @@
           this.view.focus();
         } else if (event.keyCode >= 65 && event.keyCode <= 90 && this.selectedIndex >= 0) {
           let { diagnostic } = this.items[this.selectedIndex], keys2 = assignKeys(diagnostic.actions);
-          for (let i = 0; i < keys2.length; i++)
-            if (keys2[i].toUpperCase().charCodeAt(0) == event.keyCode) {
+          for (let i2 = 0; i2 < keys2.length; i2++)
+            if (keys2[i2].toUpperCase().charCodeAt(0) == event.keyCode) {
               let found = findDiagnostic(this.view.state.field(lintState).diagnostics, diagnostic);
               if (found)
-                diagnostic.actions[i].apply(view, found.from, found.to);
+                diagnostic.actions[i2].apply(view, found.from, found.to);
             }
         } else {
           return;
@@ -22675,9 +22675,9 @@
         event.preventDefault();
       };
       let onclick = (event) => {
-        for (let i = 0; i < this.items.length; i++) {
-          if (this.items[i].dom.contains(event.target))
-            this.moveSelection(i);
+        for (let i2 = 0; i2 < this.items.length; i2++) {
+          if (this.items[i2].dom.contains(event.target))
+            this.moveSelection(i2);
         }
       };
       this.list = crelt("ul", {
@@ -22699,14 +22699,14 @@
       let selected = this.view.state.field(lintState).selected;
       if (!selected)
         return -1;
-      for (let i = 0; i < this.items.length; i++)
-        if (this.items[i].diagnostic == selected.diagnostic)
-          return i;
+      for (let i2 = 0; i2 < this.items.length; i2++)
+        if (this.items[i2].diagnostic == selected.diagnostic)
+          return i2;
       return -1;
     }
     update() {
       let { diagnostics, selected } = this.view.state.field(lintState);
-      let i = 0, needsSync = false, newSelectedItem = null;
+      let i2 = 0, needsSync = false, newSelectedItem = null;
       let seen = /* @__PURE__ */ new Set();
       diagnostics.between(0, this.view.state.doc.length, (_start, _end, { spec }) => {
         for (let diagnostic of spec.diagnostics) {
@@ -22714,19 +22714,19 @@
             continue;
           seen.add(diagnostic);
           let found = -1, item;
-          for (let j = i; j < this.items.length; j++)
+          for (let j = i2; j < this.items.length; j++)
             if (this.items[j].diagnostic == diagnostic) {
               found = j;
               break;
             }
           if (found < 0) {
             item = new PanelItem(this.view, diagnostic);
-            this.items.splice(i, 0, item);
+            this.items.splice(i2, 0, item);
             needsSync = true;
           } else {
             item = this.items[found];
-            if (found > i) {
-              this.items.splice(i, found - i);
+            if (found > i2) {
+              this.items.splice(i2, found - i2);
               needsSync = true;
             }
           }
@@ -22738,10 +22738,10 @@
           } else if (item.dom.hasAttribute("aria-selected")) {
             item.dom.removeAttribute("aria-selected");
           }
-          i++;
+          i2++;
         }
       });
-      while (i < this.items.length && !(this.items.length == 1 && this.items[0].diagnostic.from < 0)) {
+      while (i2 < this.items.length && !(this.items.length == 1 && this.items[0].diagnostic.from < 0)) {
         needsSync = true;
         this.items.pop();
       }
@@ -22972,7 +22972,7 @@
   // node_modules/@codemirror/legacy-modes/mode/ruby.js
   function wordObj(words) {
     var o = {};
-    for (var i = 0, e = words.length; i < e; ++i) o[words[i]] = true;
+    for (var i2 = 0, e = words.length; i2 < e; ++i2) o[words[i2]] = true;
     return o;
   }
   var keywordList = [


### PR DESCRIPTION
## Summary
- Cherry-pick Dependabot PR #59 to update `esbuild` from 0.28.0 to 0.28.1.
- Cherry-pick Dependabot PR #58 to update `eslint` from 10.4.1 to 10.5.0.
- Regenerate the checked-in CodeMirror bundle with `esbuild` 0.28.1.

## Security review
- Reviewed the open Dependabot alert for `esbuild` (`GHSA-g7r4-m6w7-qqqr`).
- Confirmed that the vulnerable range is `>=0.27.3, <0.28.1` and the first patched version is `0.28.1`.
- Confirmed that the failed `npm audit` check on the standalone eslint PR was caused by the still-vulnerable `esbuild@0.28.0`, not by the eslint update.

## Validation
- `npm ci`
- `npm run build:codemirror`
- `npm run lint` (passes with the existing unused `err` warning in `public_html/js/state/ble-command-queue.js`)
- `npm run lint:html`
- `npm run lint:json`
- `npm run lint:static`
- `npm run check-version`
- `npm audit --audit-level=high`
- `npm ls --depth=0`
- `git diff --check`
- `node --check public_html/codemirror/codemirror.js`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/openblink/openblink-webide/pull/60" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->